### PR TITLE
Update deployment readmes

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -23,7 +23,7 @@ The playbooks automatically install `Docker`, `docker-compose`, `Python`, `Git`a
 
 ## Configuration
 
-Please see the [bridge-nodejs README](bridge-nodejs/README.md) for configuration and execution details. 
+Please see the [Oracle](../oracle/README.md) for configuration and execution details. 
 
 ## Bridge service commands
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,12 +4,7 @@ Ansible playbooks for deploying cross-chain bridges.
 ## Overview
 Please refer to the [POA Token Bridge](../README.md) overview first of all.
 
-These playbooks are designed to automate the deployment process for cross-chain bridges on bridge validator nodes. This process installs the bridge as a service and sets .env configurations on a remote server. Playbooks for the current token-bridge deployment are located in the [bridge-nodejs](bridge-nodejs) folder.
-
-
-### Rust Bridge Playbooks
-
-The Rust bridge is not currently in production, but an Ansible playbook is developed for this implementation. It is available in the [upgradable-wo-parity](upgradable-wo-parity)folder. 
+These playbooks are designed to automate the deployment process for cross-chain bridges on bridge validator nodes. This process installs the bridge as a service and sets .env configurations on a remote server. Playbooks for the current Token Bridge Oracle deployment are located in the [Oracle](oracle) folder.
 
 ## Dependencies
 

--- a/deployment/oracle/README.md
+++ b/deployment/oracle/README.md
@@ -53,7 +53,7 @@ cp hosts.yml.example hosts.yml
 
 1. The `group_vars/<bridge_name>.yml` file contains the public bridge parameters. This file is prepared by administrators for each bridge. The validator only needs to add the required bridge name in the hosts.yml file to tell Ansible which file to use.
 
-   `group_vars/example.yml` shows an example configuration for the POA/Sokol - POA/Sokol bridge. Parameter values should match values from the .env file for the token-bridge. See [Configuration parameters](../../oracle/README.md#configuration-parameters) https://github.com/poanetwork/token-bridge#configuration-parameters for details.
+   `group_vars/example.yml` shows an example configuration for the POA/Sokol - POA/Sokol bridge. Parameter values should match values from the .env file for the token-bridge. See [Configuration parameters](../../oracle/README.md#configuration-parameters) for details.
 
 2. You can also add the following parameters in the `group_vars` to change the default behavior of `deployment-bridge` playbooks:
 

--- a/deployment/oracle/README.md
+++ b/deployment/oracle/README.md
@@ -11,10 +11,10 @@
 
 ### Configuration
 
-1. Clone this repository and go to the `bridge-nodejs` folder
+1. Clone this repository and go to the `deployment/oracle` folder
 ```
-git clone https://github.com/poanetwork/deployment-bridge.git
-cd deployment-bridge/bridge-nodejs
+git clone https://github.com/poanetwork/tokenbridge
+cd tokenbridge/deployment/oracle
 ```
 2. Create the file `hosts.yml` from `hosts.yml.example`
 ```
@@ -53,7 +53,7 @@ cp hosts.yml.example hosts.yml
 
 1. The `group_vars/<bridge_name>.yml` file contains the public bridge parameters. This file is prepared by administrators for each bridge. The validator only needs to add the required bridge name in the hosts.yml file to tell Ansible which file to use.
 
-   `group_vars/example.yml` shows an example configuration for the POA/Sokol - POA/Sokol bridge. Parameter values should match values from the .env file for the token-bridge. See https://github.com/poanetwork/token-bridge#configuration-parameters for details.
+   `group_vars/example.yml` shows an example configuration for the POA/Sokol - POA/Sokol bridge. Parameter values should match values from the .env file for the token-bridge. See [Configuration parameters](../../oracle/README.md#configuration-parameters) https://github.com/poanetwork/token-bridge#configuration-parameters for details.
 
 2. You can also add the following parameters in the `group_vars` to change the default behavior of `deployment-bridge` playbooks:
 


### PR DESCRIPTION
Fixes #40 
Fixes #24 

There is a `bridge_repo` in `deployment/oracle` readme which defaults to `https://github.com/poanetwork/token-bridge`. I created a separate issue to change it #43 because I'm not familiar with ansible so I don't know if just changing this has any impact.