### PR TITLE
Fix the docker-related logrotation config

### DIFF
--- a/deployment/oracle/roles/logging/tasks/main.yml
+++ b/deployment/oracle/roles/logging/tasks/main.yml
@@ -23,7 +23,7 @@
     dest: /etc/rsyslog.d/30-docker.conf
     owner: root
     group: root
-    mode: 644
+    mode: 0644
 
 - name: Set the log configuration file to send container logs to remote server
   template:
@@ -31,7 +31,7 @@
     dest: /etc/rsyslog.d/35-remote-logging.conf
     owner: root
     group: root
-    mode: 644
+    mode: 0644
   when: syslog_server_port is defined
 
 - name: Set the logrotate config file
@@ -40,7 +40,7 @@
     dest: /etc/logrotate.d/docker-logs
     owner: root
     group: root
-    mode: 644
+    mode: 0644
 
 - name: Discarding unwanted messages in rsyslog
   blockinfile:


### PR DESCRIPTION
From Ansible README:
For those used to `/usr/bin/chmod` remember that modes are actually octal numbers. 
You must either add a leading zero so that Ansible's YAML parser knows it is an octal number (like 0644 or 01777), or quote it (like '644' or '1777') so Ansible receives a string and can do its own conversion from string into number.

The error was in using `644` mode instead of `0644`