### PR TITLE
Added Coveralls for UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,8 @@ jobs:
       - checkout
       - run: git submodule update --init
       - run: yarn
-      - run: yarn workspace ui run build
-      - run: yarn workspace ui run build coverage
-      - run: yarn workspace ui run build coveralls
+      - run: yarn workspace ui run coverage
+      - run: yarn workspace ui run coveralls
 workflows:
   version: 2
   coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,24 @@ jobs:
         - run: yarn
         - setup_remote_docker
         - run: yarn run ui-e2e
-
+  cover:
+    docker:
+      - image: circleci/node:10.15
+    steps:
+      - checkout
+      - run: git submodule update --init
+      - run: yarn
+      - run: yarn workspace ui run build
+      - run: yarn workspace ui run build coverage
+      - run: yarn workspace ui run build coveralls
 workflows:
   version: 2
+  coverage:
+    jobs:
+      - cover:
+          filters:
+            branches:
+              only: master
   tokenbridge:
     jobs:
       - lint

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: circleci

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![CircleCI](https://circleci.com/gh/poanetwork/tokenbridge.svg?style=svg)](https://circleci.com/gh/poanetwork/tokenbridge)
 [![Gitter](https://badges.gitter.im/poanetwork/poa-bridge.svg)](https://gitter.im/poanetwork/poa-bridge?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License: LGPL v3.0](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
-[![Coverage Status](https://coveralls.io/repos/github/poanetwork/tokenbridge/badge.svg?branch=master)](https://coveralls.io/github/poanetwork/tokenbridge?branch=master)
 
 # Tokenbridge
 Welcome to the **POA Token Bridge** monorepository!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Gitter](https://badges.gitter.im/poanetwork/poa-bridge.svg)](https://gitter.im/poanetwork/poa-bridge?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License: LGPL v3.0](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 [![Coverage Status](https://coveralls.io/repos/github/poanetwork/tokenbridge/badge.svg?branch=master)](https://coveralls.io/github/poanetwork/tokenbridge?branch=master)
-[![Dependencies Status](https://david-dm.org/poanetwork/tokenbridge/status.svg)](https://david-dm.org/poanetwork/tokenbridge)
 
 # Tokenbridge
 Welcome to the **POA Token Bridge** monorepository!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CircleCI](https://circleci.com/gh/poanetwork/tokenbridge.svg?style=svg)](https://circleci.com/gh/poanetwork/tokenbridge)
 [![Gitter](https://badges.gitter.im/poanetwork/poa-bridge.svg)](https://gitter.im/poanetwork/poa-bridge?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License: LGPL v3.0](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+[![Coverage Status](https://coveralls.io/repos/github/poanetwork/tokenbridge/badge.svg?branch=master)](https://coveralls.io/github/poanetwork/tokenbridge?branch=master)
 
 # Tokenbridge
 Welcome to the **POA Token Bridge** monorepository!

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Gitter](https://badges.gitter.im/poanetwork/poa-bridge.svg)](https://gitter.im/poanetwork/poa-bridge?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License: LGPL v3.0](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 [![Coverage Status](https://coveralls.io/repos/github/poanetwork/tokenbridge/badge.svg?branch=master)](https://coveralls.io/github/poanetwork/tokenbridge?branch=master)
+[![Dependencies Status](https://david-dm.org/poanetwork/tokenbridge/status.svg)](https://david-dm.org/poanetwork/tokenbridge)
 
 # Tokenbridge
 Welcome to the **POA Token Bridge** monorepository!

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/poanetwork/tokenbridge/badge.svg?branch=master)](https://coveralls.io/github/poanetwork/tokenbridge?branch=master)
+
 # POA Token Bridge / UI
 DApp interface to transfer tokens and coins between chains.
 


### PR DESCRIPTION
- Added Coveralls coverage check for the `master` branch
- The badge has been put into ui/readme sub-dir - not sure if we want it on root readme
- Apparently `david-dm` dependency check does not work with mono-repos. If we're OK with skipping it, this PR closes #26 