### PR TITLE
Migration of latest changes from the oracle and UI repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ This project is licensed under the GNU Lesser General Public License v3.0. See t
 ## References
 
 * [Additional Documentation](https://forum.poa.network/c/tokenbridge)
-* [POA Bridge FAQ](https://poanet.zendesk.com/hc/en-us/categories/360000349273-POA-Bridge)
+* [POA20 Bridge FAQ](https://forum.poa.network/c/tokenbridge/poa20-bridge)

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -112,6 +112,9 @@ There are two options to run the TokenBridge processes:
 
 All [watcher](#watcher) & [sender](#sender) services launch when `docker-compose` is called. 
 
+Redis and RabbitMQ data are placed in `~/bridge_data` directory.
+In case you need to reset your bridge or setup a new one (with different configuration) you must delete this directory to prevent old data from being read.
+
 **Note**: To view the Docker logs:
 * `chdir` to the directory containing the `docker-compose.yml` file used to run the bridge instance
 * [View the logs](https://docs.docker.com/v17.09/compose/reference/logs/) : `docker-compose logs`

--- a/ui/README.md
+++ b/ui/README.md
@@ -50,7 +50,7 @@ The same address is used to send a coin from the Home network and receive a toke
 - Wallet Resources
   - [MetaMask](https://consensys.zendesk.com/hc/en-us/categories/360001045692-Using-MetaMask)
   - [Nifty Wallet](https://poanet.zendesk.com/hc/en-us/articles/360008957634-Nifty-Wallet)
-  - [AlphaWallet (iOS and Android)](https://alphawallet.github.io/AlphaWallet-Download-Page/)
+  - [AlphaWallet (iOS and Android)](https://alphawallet.com/)
 
 ## Getting Started
 
@@ -61,7 +61,7 @@ The following is an example setup using the POA Sokol testnet as the Home networ
 - [poa-bridge-contracts](https://github.com/poanetwork/poa-bridge-contracts)
 - [oracle](../oracle/README.md)
 - [node.js](https://nodejs.org/en/download/)
-- [AlphaWallet](https://alphawallet.github.io/AlphaWallet-Download-Page/) or [Nifty Wallet](https://github.com/poanetwork/nifty-wallet) or [MetaMask](https://metamask.io/)
+- [AlphaWallet](https://alphawallet.com/) or [Nifty Wallet](https://github.com/poanetwork/nifty-wallet) or [MetaMask](https://metamask.io/)
 
 ### Example Setup
 


### PR DESCRIPTION
There are few changes in the README files appeared after picking up sources for the monorepo from the original repositories:
  * [update AlphaWallet links to point to website](https://github.com/poanetwork/bridge-ui/pull/218)
  * [Update README.md](https://github.com/poanetwork/token-bridge/pull/143)
  * [Update README with details about redis and rabbit volume in docker](https://github.com/poanetwork/token-bridge/pull/147)

They needed to be migrated to the monorepo before the oracle and UI repositories will be archived.