### PR TITLE
Update Contracts to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ui-e2e": "./ui-e2e/run-tests.sh",
     "clean": "rm -rf ./node_modules ./**/node_modules ./**/**/node_modules ./**/build",
     "compile:contracts": "yarn workspace poa-parity-bridge-contracts run compile",
-    "install:deploy": "cd contracts/deploy && rm -f package-lock.json && npm install --silent",
+    "install:deploy": "cd contracts/deploy && npm install --silent",
     "postinstall": "ln -s $(pwd)/node_modules/openzeppelin-solidity/ contracts/node_modules/openzeppelin-solidity"
   }
 }


### PR DESCRIPTION
- Update contracts to 2.3.2
- This [fix](https://github.com/poanetwork/poa-bridge-contracts/pull/188) allows to not remove `package-lock.json` when installing dependencies in `contracts/deploy`