### PR TITLE
CI performance impovements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
            keys:
              - yarn-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run: yarn install --frozen-lockfile
-      - run: yarn install:deploy
+      - run: mkdir /tmp/artifacts && yarn install:deploy &> /tmp/artifacts/install_deploy.log
+      - store_artifacts:
+          path: /tmp/artifacts/install_deploy.log
       - run: yarn compile:contracts
       - save_cache:
            name: Save Yarn Package Cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
            name: Restore Yarn Package Cache
            keys:
              - yarn-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn install:deploy
       - run: yarn compile:contracts
       - save_cache:
@@ -59,8 +59,8 @@ jobs:
     steps:
         - checkout
         - run: git submodule update --init
-        - run: yarn
-        - setup_remote_docker
+        - setup_remote_docker:
+            docker_layer_caching: true
         - run: yarn run oracle-e2e
   ui-e2e:
     machine:
@@ -77,7 +77,7 @@ jobs:
       - run: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
       - run: sudo dpkg -i google-chrome-stable_current_amd64.deb
       - run: git submodule update --init
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: yarn run ui-e2e
   cover:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,18 +10,28 @@ jobs:
            name: Restore Yarn Package Cache
            keys:
              - yarn-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+      - run: git submodule status > submodule.status 
+      - restore_cache:
+           name: Restore contracts submodule with compiled contracts
+           keys:
+             - contracts-{{ checksum "submodule.status" }}
       - run: yarn install --frozen-lockfile
-      - run: mkdir /tmp/artifacts && yarn install:deploy &> /tmp/artifacts/install_deploy.log
-      - store_artifacts:
-          path: /tmp/artifacts/install_deploy.log
-      - run: yarn compile:contracts
       - save_cache:
            name: Save Yarn Package Cache
            key: yarn-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
            paths:
              - ~/.cache/yarn
+      - run: touch install_deploy.log; test -d contracts/build/contracts || yarn install:deploy &> install_deploy.log
+      - store_artifacts:
+          path: install_deploy.log
+      - run: test -d contracts/build/contracts || yarn compile:contracts
       - save_cache:
-          name: Save initialized project
+           name: Save contracts submodule with compiled contracts
+           key: contracts-{{ checksum "submodule.status" }}
+           paths:
+             - contracts
+      - save_cache:
+          name: Save initialized project for subsequent jobs
           key: initialize-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,18 +27,15 @@ jobs:
     docker:
       - image: circleci/node:10.15
     steps:
-      - checkout
-      - run: git submodule update --init
-      - run: yarn
+      - restore_cache:
+          key: initialize-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn run build
   lint:
     docker:
       - image: circleci/node:10.15
     steps:
-      - checkout
-      - run: git submodule update --init
-      - run: yarn
-      - run: yarn compile:contracts
+      - restore_cache:
+          key: initialize-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn run lint
   ansible-lint:
     docker:
@@ -53,10 +50,8 @@ jobs:
       HOME_RPC_URL: http://example.com
       FOREIGN_RPC_URL: http://example.com
     steps:
-      - checkout
-      - run: git submodule update --init
-      - run: yarn
-      - run: yarn compile:contracts
+      - restore_cache:
+          key: initialize-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn run test
   oracle-e2e:
     docker:
@@ -88,9 +83,8 @@ jobs:
     docker:
       - image: circleci/node:10.15
     steps:
-      - checkout
-      - run: git submodule update --init
-      - run: yarn
+      - restore_cache:
+          key: initialize-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn workspace ui run coverage
       - run: yarn workspace ui run coveralls
 workflows:
@@ -98,13 +92,21 @@ workflows:
   tokenbridge:
     jobs:
       - initialize
+      - build:
+          requires:
+            - initialize
+      - lint:
+          requires:
+            - initialize
+      - test:
+          requires:
+            - initialize
       - cover:
+          requires:
+            - initialize
           filters:
             branches:
               only: master
-      - build
-      - lint
       - ansible-lint
-      - test
       - oracle-e2e
       - ui-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
   ui-e2e:
     machine:
       image: circleci/classic:latest
+      docker_layer_caching: true
     steps:
       - checkout
       - run: |
@@ -77,7 +78,16 @@ jobs:
       - run: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
       - run: sudo dpkg -i google-chrome-stable_current_amd64.deb
       - run: git submodule update --init
+      - restore_cache:
+           name: Restore Machine Yarn Package Cache
+           keys:
+             - yarn-machine-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run: yarn install --frozen-lockfile
+      - save_cache:
+           name: Save Machine Yarn Package Cache
+           key: yarn-machine-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+           paths:
+             - ~/.cache/yarn
       - run: yarn run ui-e2e
   cover:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,28 @@
 version: 2
 jobs:
+  initialize:
+    docker:
+      - image: circleci/node:10.15
+    steps:
+      - checkout
+      - run: git submodule update --init
+      - restore_cache:
+           name: Restore Yarn Package Cache
+           keys:
+             - yarn-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+      - run: yarn install
+      - run: yarn install:deploy
+      - run: yarn compile:contracts
+      - save_cache:
+           name: Save Yarn Package Cache
+           key: yarn-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+           paths:
+             - ~/.cache/yarn
+      - save_cache:
+          name: Save initialized project
+          key: initialize-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/project
   build:
     docker:
       - image: circleci/node:10.15
@@ -72,14 +95,13 @@ jobs:
       - run: yarn workspace ui run coveralls
 workflows:
   version: 2
-  coverage:
+  tokenbridge:
     jobs:
+      - initialize
       - cover:
           filters:
             branches:
               only: master
-  tokenbridge:
-    jobs:
       - build
       - lint
       - ansible-lint

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "contracts"
   ],
   "scripts": {
-    "build": "yarn run compile:contracts && yarn workspace ui run build",
+    "build": "yarn workspace ui run build",
     "lint": "yarn wsrun --exclude oracle-e2e --exclude ui-e2e --exclude poa-parity-bridge-contracts lint",
-    "test": "yarn run compile:contracts && yarn wsrun --exclude monitor --exclude oracle-e2e --exclude ui-e2e test",
+    "test": "yarn wsrun --exclude monitor --exclude oracle-e2e --exclude ui-e2e test",
     "ansible-lint": "./deployment/lint.sh",
     "oracle-e2e": "./oracle-e2e/run-tests.sh",
     "ui-e2e": "./ui-e2e/run-tests.sh",

--- a/ui-e2e/package.json
+++ b/ui-e2e/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "license": "MIT",
   "private": true,
-  "devDependencies": {},
+  "devDependencies": {
+    "selenium-webdriver": "3.6.0"
+  },
   "scripts": {
     "deploy": "node ./scripts/deploy.js"
   }

--- a/ui-e2e/run-tests.sh
+++ b/ui-e2e/run-tests.sh
@@ -23,11 +23,7 @@ docker-compose run -d -p 3002:3000 ui-erc20-native yarn workspace ui run start
 
 yarn mocha -b ./test.js
 rc=$?
-
-if [ $CI ]
-then
-  exit $rc
-fi
+if [ $CI ]; then exit $rc; fi
 
 ps | grep node | grep -v grep | awk '{print "kill " $1}' | sh
 docker-compose down

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,6 @@
     "react-router-dom": "^4.2.2",
     "react-scripts": "3.0.1",
     "react-transition-group": "^2.2.1",
-    "selenium-webdriver": "^3.6.0",
     "sweetalert": "^2.1.0",
     "web3": "1.0.0-beta.30",
     "web3-utils": "1.0.0-beta.30"


### PR DESCRIPTION
#### The following has been done in order to improve CI performance:
- Introduced an `Initialize` job that initializes the project with dependencies and compiles the contracts
  - The result, saved in CI cache, is used by subsequent `build`, `lint`,  `test` and `cover` jobs
- Yarn's cache is saved in CI cache to use in every `Initialize` run
- Compiled contracts are saved in CI cache to use in every `Initialize` run
  - The cache is based on a key with commit hash of the `contracts`, so if we update `contracts` submodule then the cache will be invalidated
- Saving `yarn install:deploy` output in a CI artifact in order to get rid of large wall of text in CI logs coming from `node-gyp` that does not conform to `--silent` switch

#### E2E
- The e2e sub-projects cannot make use of the `Initialize` job because all of the initialization, installing dependencies, compiling contracts happens in the docker build system.
- Enabling `docker layer caching` allows to cache built docker layers in the e2e jobs run
  - Apparently the `docker layer caching` performance varies, not always the layers are taken from cache. I have included slower and quicker runs in the results

#### Notes
- From what I've read the `docker layer caching` feature might become a paid feature in the future
- I didn't find any more improvements, also I don't think that we can share pulling parity, redis etc. docker images between the e2e jobs. I'd say we close #65 but keep eye on further opportunities for improvement

### Results

#### Before (current master)
<img width="224" alt="Screenshot 2019-05-31 at 15 36 43" src="https://user-images.githubusercontent.com/12039224/58709192-effc7980-83b9-11e9-90a4-3929aafa0d66.png">


#### After, slowest run
<img width="476" alt="Screenshot 2019-05-31 at 15 37 22" src="https://user-images.githubusercontent.com/12039224/58709224-01de1c80-83ba-11e9-96c3-ad044a52ed05.png">

#### After, quicker `oracle-e2e` run
<img width="466" alt="Screenshot 2019-05-31 at 15 37 39" src="https://user-images.githubusercontent.com/12039224/58710357-68fcd080-83bc-11e9-8c04-a85507530bf7.png">

#### After, quicker `ui-e2e` run
<img width="469" alt="Screenshot 2019-05-31 at 15 48 43" src="https://user-images.githubusercontent.com/12039224/58709992-a14fdf00-83bb-11e9-8bf4-ca55278b5739.png">

