### PR TITLE
UI - New way of getting env variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,6 @@ jobs:
   test:
     docker:
       - image: circleci/node:10.15
-    environment:
-      HOME_RPC_URL: http://example.com
-      FOREIGN_RPC_URL: http://example.com
     steps:
       - restore_cache:
           key: initialize-{{ .Environment.CIRCLE_SHA1 }}

--- a/oracle/config/affirmation-request-watcher.config.js
+++ b/oracle/config/affirmation-request-watcher.config.js
@@ -1,4 +1,3 @@
-require('dotenv').config()
 const baseConfig = require('./base.config')
 const erc20Abi = require('../../contracts/build/contracts/ERC20').abi
 const { ERC_TYPES } = require('../src/utils/constants')

--- a/oracle/config/base.config.js
+++ b/oracle/config/base.config.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../env')
 
 const { toBN } = require('web3').utils
 const { web3Home, web3Foreign } = require('../src/services/web3')

--- a/oracle/config/foreign-sender.config.js
+++ b/oracle/config/foreign-sender.config.js
@@ -1,4 +1,3 @@
-require('dotenv').config()
 const baseConfig = require('./base.config')
 
 const { web3Foreign } = require('../src/services/web3')

--- a/oracle/config/home-sender.config.js
+++ b/oracle/config/home-sender.config.js
@@ -1,4 +1,3 @@
-require('dotenv').config()
 const baseConfig = require('./base.config')
 
 const { web3Home } = require('../src/services/web3')

--- a/oracle/env.js
+++ b/oracle/env.js
@@ -1,0 +1,4 @@
+const path = require('path')
+require('dotenv').config({
+  path: path.join(__dirname, process.env.NODE_ENV === 'test' ? './test/test.env' : './.env')
+})

--- a/oracle/scripts/erc20_to_erc20/sendForeign.js
+++ b/oracle/scripts/erc20_to_erc20/sendForeign.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../../.env')
-})
+require('../../env')
 const Web3 = require('web3')
 const Web3Utils = require('web3-utils')
 const rpcUrlsManager = require('../../src/services/getRpcUrlsManager')

--- a/oracle/scripts/erc20_to_erc20/sendHome.js
+++ b/oracle/scripts/erc20_to_erc20/sendHome.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../../.env')
-})
+require('../../env')
 const Web3 = require('web3')
 const Web3Utils = require('web3-utils')
 const rpcUrlsManager = require('../../src/services/getRpcUrlsManager')

--- a/oracle/scripts/erc20_to_native/sendForeign.js
+++ b/oracle/scripts/erc20_to_native/sendForeign.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../../.env')
-})
+require('../../env')
 const Web3 = require('web3')
 const Web3Utils = require('web3-utils')
 const rpcUrlsManager = require('../../src/services/getRpcUrlsManager')

--- a/oracle/scripts/erc20_to_native/sendHome.js
+++ b/oracle/scripts/erc20_to_native/sendHome.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../../.env')
-})
+require('../../env')
 const Web3Utils = require('web3-utils')
 const { web3Home } = require('../../src/services/web3')
 const { sendTx, sendRawTx } = require('../../src/tx/sendTx')

--- a/oracle/scripts/getValidatorStartBlocks.js
+++ b/oracle/scripts/getValidatorStartBlocks.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../.env')
-})
+require('../env')
 const Web3 = require('web3')
 const bridgeValidatorsABI = require('../../contracts/build/contracts/BridgeValidators').abi
 

--- a/oracle/scripts/initialChecks.js
+++ b/oracle/scripts/initialChecks.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../.env')
-})
+require('../env')
 const Web3 = require('web3')
 const ERC677BridgeTokenABI = require('../../contracts/build/contracts/ERC677BridgeToken').abi
 const { ERC_TYPES } = require('../src/utils/constants')

--- a/oracle/scripts/native_to_erc20/sendForeign.js
+++ b/oracle/scripts/native_to_erc20/sendForeign.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../../.env')
-})
+require('../../env')
 const Web3Utils = require('web3-utils')
 const { web3Foreign } = require('../../src/services/web3')
 const { sendTx, sendRawTx } = require('../../src/tx/sendTx')

--- a/oracle/scripts/native_to_erc20/sendHome.js
+++ b/oracle/scripts/native_to_erc20/sendHome.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../../.env')
-})
+require('../../env')
 const Web3Utils = require('web3-utils')
 const { web3Home } = require('../../src/services/web3')
 const { sendTx, sendRawTx } = require('../../src/tx/sendTx')

--- a/oracle/scripts/privateKeyToAddress.js
+++ b/oracle/scripts/privateKeyToAddress.js
@@ -1,7 +1,4 @@
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '..', '.env')
-})
+require('../env')
 const { privateKeyToAddress } = require('../src/utils/utils')
 const { EXIT_CODES } = require('../src/utils/constants')
 

--- a/oracle/scripts/resetLastBlock.js
+++ b/oracle/scripts/resetLastBlock.js
@@ -1,8 +1,5 @@
+require('../env')
 const Redis = require('ioredis')
-const path = require('path')
-require('dotenv').config({
-  path: path.join(__dirname, '../.env')
-})
 const { id } = require('../config/base.config')
 const { EXIT_CODES } = require('../src/utils/constants')
 

--- a/oracle/src/events/processAffirmationRequests/index.js
+++ b/oracle/src/events/processAffirmationRequests/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../../../env')
 const promiseLimit = require('promise-limit')
 const { HttpListProviderError } = require('http-list-provider')
 const rootLogger = require('../../services/logger')

--- a/oracle/src/events/processCollectedSignatures/index.js
+++ b/oracle/src/events/processCollectedSignatures/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../../../env')
 const promiseLimit = require('promise-limit')
 const { HttpListProviderError } = require('http-list-provider')
 const bridgeValidatorsABI = require('../../../../contracts/build/contracts/BridgeValidators').abi

--- a/oracle/src/events/processSignatureRequests/index.js
+++ b/oracle/src/events/processSignatureRequests/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../../../env')
 const promiseLimit = require('promise-limit')
 const { HttpListProviderError } = require('http-list-provider')
 const bridgeValidatorsABI = require('../../../../contracts/build/contracts/BridgeValidators').abi

--- a/oracle/src/events/processTransfers/index.js
+++ b/oracle/src/events/processTransfers/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../../../env')
 const promiseLimit = require('promise-limit')
 const { HttpListProviderError } = require('http-list-provider')
 const bridgeValidatorsABI = require('../../../../contracts/build/contracts/BridgeValidators').abi

--- a/oracle/src/sender.js
+++ b/oracle/src/sender.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../env')
 const path = require('path')
 const { connectSenderToQueue } = require('./services/amqpClient')
 const { redis, redlock } = require('./services/redisClient')

--- a/oracle/src/services/amqpClient.js
+++ b/oracle/src/services/amqpClient.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../../env')
 const connection = require('amqp-connection-manager').connect(process.env.QUEUE_URL)
 const logger = require('./logger')
 

--- a/oracle/src/services/gasPrice.js
+++ b/oracle/src/services/gasPrice.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../../env')
 const fetch = require('node-fetch')
 const Web3Utils = require('web3-utils')
 const { web3Home, web3Foreign } = require('../services/web3')

--- a/oracle/src/watcher.js
+++ b/oracle/src/watcher.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('../env')
 const path = require('path')
 const { BN, toBN } = require('web3').utils
 const { connectWatcherToQueue, connection } = require('./services/amqpClient')

--- a/oracle/test/test.env
+++ b/oracle/test/test.env
@@ -1,0 +1,2 @@
+HOME_RPC_URL=http://example.com
+FOREIGN_RPC_URL=http://example.com


### PR DESCRIPTION
New way of getting env variables.
`oracle/env.js` is used as a proxy to `dotenv` module.
Puts an end to arbitrary `.env` file required for the ui tests to pass, and removes arbitrary environment variables added to the `test` job in CI.

Closes #90 