### PR TITLE
UI in docker

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -11,7 +11,7 @@ COPY monitor/package.json ./monitor/
 COPY contracts/package.json ./contracts/
 
 COPY yarn.lock .
-RUN yarn install
+RUN yarn install --frozen-lockfile
 COPY ./contracts ./contracts
 RUN yarn install:deploy
 RUN yarn compile:contracts

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -9,7 +9,6 @@ COPY ui/lib/web3-eth/index.js ./ui/lib/web3-eth/index.js
 COPY ui-e2e/package.json ./ui-e2e/
 COPY monitor/package.json ./monitor/
 COPY contracts/package.json ./contracts/
-COPY ui/lib/web3-eth/index.js ./ui/lib/web3-eth/index.js
 
 COPY yarn.lock .
 RUN yarn install

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -2,12 +2,7 @@ FROM node:10
 
 WORKDIR /mono
 COPY package.json .
-COPY oracle/package.json ./oracle/
 COPY oracle-e2e/package.json ./oracle-e2e/
-COPY ui/package.json ./ui/
-COPY ui/lib/web3-eth/index.js ./ui/lib/web3-eth/index.js
-COPY ui-e2e/package.json ./ui-e2e/
-COPY monitor/package.json ./monitor/
 COPY contracts/package.json ./contracts/
 
 COPY yarn.lock .

--- a/e2e-commons/docker-compose.yml
+++ b/e2e-commons/docker-compose.yml
@@ -108,7 +108,7 @@ services:
   ui:
     build:
       context: ..
-      dockerfile: Dockerfile.e2e
+      dockerfile: ui/Dockerfile
     environment:
     - REACT_APP_HOME_BRIDGE_ADDRESS=0x32198D570fffC7033641F8A9094FFDCaAEF42624
     - REACT_APP_FOREIGN_BRIDGE_ADDRESS=0x2B6871b9B02F73fa24F4864322CdC78604207769
@@ -134,7 +134,7 @@ services:
   ui-erc20:
     build:
       context: ..
-      dockerfile: Dockerfile.e2e
+      dockerfile: ui/Dockerfile
     environment:
     - REACT_APP_HOME_BRIDGE_ADDRESS=0x1feB40aD9420b186F019A717c37f5546165d411E
     - REACT_APP_FOREIGN_BRIDGE_ADDRESS=0x4a58D6d8D416a5fBCAcf3dC52eb8bE8948E25127
@@ -160,7 +160,7 @@ services:
   ui-erc20-native:
     build:
       context: ..
-      dockerfile: Dockerfile.e2e
+      dockerfile: ui/Dockerfile
     environment:
     - REACT_APP_HOME_BRIDGE_ADDRESS=0x488Af810997eD1730cB3a3918cD83b3216E6eAda
     - REACT_APP_FOREIGN_BRIDGE_ADDRESS=0x488Af810997eD1730cB3a3918cD83b3216E6eAda

--- a/e2e-commons/up.sh
+++ b/e2e-commons/up.sh
@@ -26,9 +26,9 @@ while [ "$1" != "" ]; do
   if [ "$1" == "ui" ]; then
     docker-compose up -d ui ui-erc20 ui-erc20-native
 
-    docker-compose run -d -p 3000:3000 ui yarn workspace ui run start
-    docker-compose run -d -p 3001:3000 ui-erc20 yarn workspace ui run start
-    docker-compose run -d -p 3002:3000 ui-erc20-native yarn workspace ui run start
+    docker-compose run -d -p 3000:3000 ui yarn start
+    docker-compose run -d -p 3001:3000 ui-erc20 yarn start
+    docker-compose run -d -p 3002:3000 ui-erc20-native yarn start
   fi
 
   if [ "$1" == "deploy" ]; then

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -12,7 +12,7 @@ COPY package.json .
 COPY contracts/package.json ./contracts/
 COPY oracle/package.json ./oracle/
 COPY yarn.lock .
-RUN yarn install --production
+RUN yarn install --production --frozen-lockfile
 
 COPY ./contracts ./contracts
 RUN yarn run compile:contracts

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,7 +6,7 @@ COPY contracts/package.json ./contracts/
 COPY ui/package.json ./ui/
 COPY ui/lib/web3-eth/index.js ./ui/lib/web3-eth/index.js
 COPY yarn.lock .
-RUN yarn install --production
+RUN yarn install --production --frozen-lockfile
 
 COPY ./contracts ./contracts
 RUN yarn run compile:contracts

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:8
+
+WORKDIR /mono
+COPY package.json .
+COPY contracts/package.json ./contracts/
+COPY ui/package.json ./ui/
+COPY ui/lib/web3-eth/index.js ./ui/lib/web3-eth/index.js
+COPY yarn.lock .
+RUN yarn install --production
+
+COPY ./contracts ./contracts
+RUN yarn run compile:contracts
+RUN mv ./contracts/build ./ && rm -rf ./contracts/* ./contracts/.[!.]* && mv ./build ./contracts/
+
+COPY ./ui ./ui
+WORKDIR /mono/ui
+CMD echo "To start a UI application run:" \
+  "?"

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -15,4 +15,4 @@ RUN mv ./contracts/build ./ && rm -rf ./contracts/* ./contracts/.[!.]* && mv ./b
 COPY ./ui ./ui
 WORKDIR /mono/ui
 CMD echo "To start a UI application run:" \
-  "?"
+  "yarn start"

--- a/ui/README.md
+++ b/ui/README.md
@@ -140,8 +140,15 @@ cat ../poa-bridge-contracts/deploy/bridgeDeploymentResults.json
 ```
 
   * Run the dApp
+
+Using Yarn:
 ```
 yarn start
+```
+
+Using Docker:
+```
+docker-compose up -d
 ```
 
   * Make sure your web3 wallet (Nifty Wallet, AlphaWallet or MetaMask) is funded and connected to the POA Sokol Network (see step 2)

--- a/ui/README.md
+++ b/ui/README.md
@@ -151,6 +151,8 @@ Using Docker:
 docker-compose up -d
 ```
 
+The application will run on `http://localhost:PORT`, where `PORT` is specified in your `.env` file.
+
   * Make sure your web3 wallet (Nifty Wallet, AlphaWallet or MetaMask) is funded and connected to the POA Sokol Network (see step 2)
   * Specify an amount and click `Transfer` to complete a cross-chain transaction from Sokol to Kovan
 

--- a/ui/docker-compose.yml
+++ b/ui/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2.4'
+services:
+  ui:
+    build:
+      context: ..
+      dockerfile: ui/Dockerfile
+    ports:
+    - "${PORT}:${PORT}"
+    command: 'true'
+    env_file: ./.env
+    environment: 
+      - NODE_ENV=production
+    restart: unless-stopped
+    entrypoint: yarn start

--- a/ui/docker-compose.yml
+++ b/ui/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       dockerfile: ui/Dockerfile
     ports:
     - "${PORT}:${PORT}"
-    command: 'true'
     env_file: ./.env
     environment: 
       - NODE_ENV=production

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,7 +39,7 @@
     "coverage": "react-app-rewired test --env=jsdom --coverage",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
     "eject": "react-app-rewired eject",
-    "postinstall": "(cp lib/web3-eth/index.js ../node_modules/web3-eth/src && cp lib/web3-eth/index.js ./node_modules/web3-eth/src)"
+    "postinstall": "cp lib/web3-eth/index.js ../node_modules/web3-eth/src || cp lib/web3-eth/index.js ./node_modules/web3-eth/src || :"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
- Closes #57 
- Adds a dedicated `ui/Dockerfile`. The UI was already dockerized when running `ui-e2e` but was using `Dockerfile.e2e`
- Removes oracle, ui, monitor from the `Dockerfile.e2e`