### PR TITLE
Improve sender retry strategy

### DIFF
--- a/oracle/src/sender.js
+++ b/oracle/src/sender.js
@@ -91,7 +91,7 @@ function updateNonce(nonce) {
   return redis.set(nonceKey, nonce)
 }
 
-async function main({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
+async function main({ msg, ackMsg, nackMsg, channel, scheduleForRetry }) {
   try {
     if (redis.status !== 'ready') {
       nackMsg(msg)
@@ -167,7 +167,7 @@ async function main({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
 
     if (failedTx.length) {
       logger.info(`Sending ${failedTx.length} Failed Tx to Queue`)
-      await sendToQueue(failedTx)
+      await scheduleForRetry(failedTx, msg.properties.headers['x-retries'])
     }
     ackMsg(msg)
     logger.debug(`Finished processing msg`)

--- a/oracle/src/services/amqpClient.js
+++ b/oracle/src/services/amqpClient.js
@@ -44,18 +44,13 @@ function connectSenderToQueue({ queueName, cb }) {
           ackMsg: job => channelWrapper.ack(job),
           nackMsg: job => channelWrapper.nack(job, false, true),
           scheduleForRetry: async (data, msgRetries = 0) => {
-            const retries = msgRetries + 1
-            const delay = getRetrySequence(retries) * 1000
-            const retryQueue = `${queueName}-retry-${delay}`
-            await channel.assertQueue(retryQueue, {
-              durable: true,
-              deadLetterExchange,
-              messageTtl: delay,
-              expires: delay * 10
-            })
-            await channelWrapper.sendToQueue(retryQueue, data, {
-              persistent: true,
-              headers: { 'x-retries': retries }
+            await generateRetry({
+              data,
+              msgRetries,
+              channelWrapper,
+              channel,
+              queueName,
+              deadLetterExchange
             })
           }
         })
@@ -64,8 +59,32 @@ function connectSenderToQueue({ queueName, cb }) {
   })
 }
 
+async function generateRetry({
+  data,
+  msgRetries,
+  channelWrapper,
+  channel,
+  queueName,
+  deadLetterExchange
+}) {
+  const retries = msgRetries + 1
+  const delay = getRetrySequence(retries) * 1000
+  const retryQueue = `${queueName}-retry-${delay}`
+  await channel.assertQueue(retryQueue, {
+    durable: true,
+    deadLetterExchange,
+    messageTtl: delay,
+    expires: delay * 10
+  })
+  await channelWrapper.sendToQueue(retryQueue, data, {
+    persistent: true,
+    headers: { 'x-retries': retries }
+  })
+}
+
 module.exports = {
   connectWatcherToQueue,
   connectSenderToQueue,
-  connection
+  connection,
+  generateRetry
 }

--- a/oracle/src/utils/utils.js
+++ b/oracle/src/utils/utils.js
@@ -2,6 +2,14 @@ const BigNumber = require('bignumber.js')
 const promiseRetry = require('promise-retry')
 const Web3 = require('web3')
 
+const retrySequence = [1, 2, 3, 5, 8, 13, 21, 34, 55, 60]
+
+function getRetrySequence(count) {
+  return count > retrySequence.length
+    ? retrySequence[retrySequence.length - 1]
+    : retrySequence[count - 1]
+}
+
 async function syncForEach(array, callback) {
   for (let index = 0; index < array.length; index++) {
     await callback(array[index], index, array)
@@ -112,5 +120,6 @@ module.exports = {
   setIntervalAndRun,
   watchdog,
   privateKeyToAddress,
-  nonceError
+  nonceError,
+  getRetrySequence
 }

--- a/oracle/test/amqp.test.js
+++ b/oracle/test/amqp.test.js
@@ -1,0 +1,152 @@
+const { expect } = require('chai')
+const { generateRetry, connection } = require('../src/services/amqpClient')
+
+connection.close()
+
+describe('generateRetry', () => {
+  let channel
+  let channelWrapper
+  const data = [{}]
+  const queueName = 'test-queue'
+  const deadLetterExchange = `${queueName}-retry`
+  beforeEach(() => {
+    channel = {
+      assertQueue(queue, options) {
+        this.queue = queue
+        this.options = options
+      }
+    }
+    channelWrapper = {
+      sendToQueue(queue, data, options) {
+        this.queue = queue
+        this.data = data
+        this.options = options
+      }
+    }
+  })
+  it('should assert new queue and push the message', async () => {
+    // Given
+    const msgRetries = 0
+    const delay = 1000
+
+    // When
+    await generateRetry({
+      data,
+      msgRetries,
+      channelWrapper,
+      channel,
+      queueName,
+      deadLetterExchange
+    })
+
+    // Then
+    expect(channel.queue).to.equal(`${queueName}-retry-${delay}`)
+    expect(channel.options.messageTtl).to.equal(delay)
+    expect(channel.options.expires).to.equal(delay * 10)
+    expect(channelWrapper.options.headers['x-retries']).to.equal(msgRetries + 1)
+  })
+  it('should increment delay on retries', async () => {
+    let msgRetries = 1
+    let delay = 2000
+
+    await generateRetry({
+      data,
+      msgRetries,
+      channelWrapper,
+      channel,
+      queueName,
+      deadLetterExchange
+    })
+
+    expect(channel.queue).to.equal(`${queueName}-retry-${delay}`)
+    expect(channel.options.messageTtl).to.equal(delay)
+    expect(channel.options.expires).to.equal(delay * 10)
+    expect(channelWrapper.options.headers['x-retries']).to.equal(msgRetries + 1)
+
+    msgRetries = 2
+    delay = 3000
+
+    await generateRetry({
+      data,
+      msgRetries,
+      channelWrapper,
+      channel,
+      queueName,
+      deadLetterExchange
+    })
+
+    expect(channel.queue).to.equal(`${queueName}-retry-${delay}`)
+    expect(channel.options.messageTtl).to.equal(delay)
+    expect(channel.options.expires).to.equal(delay * 10)
+    expect(channelWrapper.options.headers['x-retries']).to.equal(msgRetries + 1)
+
+    msgRetries = 4
+    delay = 8000
+
+    await generateRetry({
+      data,
+      msgRetries,
+      channelWrapper,
+      channel,
+      queueName,
+      deadLetterExchange
+    })
+
+    expect(channel.queue).to.equal(`${queueName}-retry-${delay}`)
+    expect(channel.options.messageTtl).to.equal(delay)
+    expect(channel.options.expires).to.equal(delay * 10)
+    expect(channelWrapper.options.headers['x-retries']).to.equal(msgRetries + 1)
+  })
+  it('should have a max delay of 60 seconds', async () => {
+    let msgRetries = 10
+    let delay = 60000
+
+    await generateRetry({
+      data,
+      msgRetries,
+      channelWrapper,
+      channel,
+      queueName,
+      deadLetterExchange
+    })
+
+    expect(channel.queue).to.equal(`${queueName}-retry-${delay}`)
+    expect(channel.options.messageTtl).to.equal(delay)
+    expect(channel.options.expires).to.equal(delay * 10)
+    expect(channelWrapper.options.headers['x-retries']).to.equal(msgRetries + 1)
+
+    msgRetries = 15
+    delay = 60000
+
+    await generateRetry({
+      data,
+      msgRetries,
+      channelWrapper,
+      channel,
+      queueName,
+      deadLetterExchange
+    })
+
+    expect(channel.queue).to.equal(`${queueName}-retry-${delay}`)
+    expect(channel.options.messageTtl).to.equal(delay)
+    expect(channel.options.expires).to.equal(delay * 10)
+    expect(channelWrapper.options.headers['x-retries']).to.equal(msgRetries + 1)
+
+    msgRetries = 20
+    delay = 60000
+
+    await generateRetry({
+      data,
+      msgRetries,
+      channelWrapper,
+      channel,
+      queueName,
+      deadLetterExchange
+    })
+
+    expect(channel.queue).to.equal(`${queueName}-retry-${delay}`)
+    expect(channel.options.messageTtl).to.equal(delay)
+    expect(channel.options.expires).to.equal(delay * 10)
+    expect(channelWrapper.options.headers['x-retries']).to.equal(msgRetries + 1)
+  })
+})

--- a/oracle/test/test.env
+++ b/oracle/test/test.env
@@ -1,2 +1,3 @@
 HOME_RPC_URL=http://example.com
 FOREIGN_RPC_URL=http://example.com
+QUEUE_URL=http://example.com


### PR DESCRIPTION
See [this comment](https://github.com/poanetwork/tokenbridge/issues/94#issuecomment-500428242). When a tx fails, on rabbitmq a new queue is dynamically created (if not existed) with a message ttl calculated based on the retries attempts of that transaction. Once the message reaches the ttl, it is redirected to `deadLetterExchange` which will send the message back to the original queue that the sender is consuming. This new queue dynamically created will be autoremoved after a time of no activity.

Closes #94 