### PR TITLE
Removed obsolete e2e deploy scripts

### DIFF
--- a/oracle-e2e/package.json
+++ b/oracle-e2e/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "deploy": "node deploy.js",
     "start": "mocha"
   },
   "author": "",

--- a/ui-e2e/package.json
+++ b/ui-e2e/package.json
@@ -6,7 +6,5 @@
   "devDependencies": {
     "selenium-webdriver": "3.6.0"
   },
-  "scripts": {
-    "deploy": "node ./scripts/deploy.js"
-  }
+  "scripts": {}
 }


### PR DESCRIPTION
Deployment happens in `e2e-commons`, deploy.js files do not exists anymore.