### PR TITLE
Increase of EXTRA_GAS_PERCENTAGE

### DIFF
--- a/oracle/src/utils/constants.js
+++ b/oracle/src/utils/constants.js
@@ -1,5 +1,5 @@
 module.exports = {
-  EXTRA_GAS_PERCENTAGE: 1,
+  EXTRA_GAS_PERCENTAGE: 4,
   MAX_CONCURRENT_EVENTS: 50,
   RETRY_CONFIG: {
     retries: 20,


### PR DESCRIPTION
The coefficient increased as a temporary fix to address the issue (https://github.com/poanetwork/token-bridge/issues/126) with incorrect estimatGas call due to concurrent concurrent transactions from different validators.