### PR TITLE
Monitor in docker

### DIFF
--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:8
+
+WORKDIR /mono
+COPY package.json .
+COPY contracts/package.json ./contracts/
+COPY monitor/package.json ./monitor/
+COPY yarn.lock .
+RUN yarn install --frozen-lockfile --production
+
+COPY ./contracts ./contracts
+RUN yarn run compile:contracts
+RUN mv ./contracts/build ./ && rm -rf ./contracts/* ./contracts/.[!.]* && mv ./build ./contracts/
+
+COPY ./monitor ./monitor
+WORKDIR /mono/monitor
+CMD echo "To start the monitor run:" \
+  "yarn start"

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -124,7 +124,8 @@ Using Docker:
 docker-compose up -d
 ```
 
-To enabled debug logging, set `DEBUG=1` env variable.
+- The application will run on `http://localhost:PORT`, where `PORT` is specified in your `.env` file.
+- To enabled debug logging, set `DEBUG=1` variable in `.env`.
 
 ## Check balances of contracts and validators, get unprocessed events
 

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -122,22 +122,35 @@ GAS_PRICE_FALLBACK=21
 LEFT_TX_THRESHOLD=100
 ```
 
-## Check balances of contracts and validators
-```
-node checkWorker.js
-```
-
-## Check unprocessed events
-```
-node checkWorker2.js
-```
-
 ## Run web interface
+
+Using Yarn:
 ```
 yarn start
 ```
 
+You can run web interface via [pm2](https://www.npmjs.com/package/pm2) or similar supervisor program.
+
+Using Docker:
+```
+docker-compose up -d
+```
+
 To enabled debug logging, set `DEBUG=1` env variable.
+
+## Check balances of contracts and validators, get unprocessed events
+
+Using Yarn:
+```
+yarn check-all
+```
+
+Using Docker:
+```
+docker-compose exec monitor yarn check-all
+```
+
+### Cron
 
 You can create cron job to run workers (see `crontab.example` for reference):
 ```bash
@@ -146,8 +159,6 @@ You can create cron job to run workers (see `crontab.example` for reference):
 */5 * * * * cd $HOME/bridge-monitor; node checkWorker2.js >>cronWorker2.out 2>>cronWorker2.err
 ```
 
-You can run web interface via [pm2](https://www.npmjs.com/package/pm2) or similar supervisor program.
-
 ## Linting
 
 Running linter:
@@ -155,7 +166,6 @@ Running linter:
 ```bash
 yarn lint
 ```
-
 
 ## Contributing
 

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -110,18 +110,6 @@ cd monitor
 cp .env.example .env
 ```
 
-#### Example:
-```bash
-HOME_RPC_URL=https://sokol.poa.network
-FOREIGN_RPC_URL=https://kovan.infura.io/mew
-HOME_BRIDGE_ADDRESS=0xABb4C1399DcC28FBa3Beb76CAE2b50Be3e087353
-FOREIGN_BRIDGE_ADDRESS=0xE405F6872cE38a7a4Ff63DcF946236D458c2ca3a
-GAS_PRICE_SPEED_TYPE=standard
-GAS_LIMIT=300000
-GAS_PRICE_FALLBACK=21
-LEFT_TX_THRESHOLD=100
-```
-
 ## Run web interface
 
 Using Yarn:
@@ -153,11 +141,6 @@ docker-compose exec monitor yarn check-all
 ### Cron
 
 You can create cron job to run workers (see `crontab.example` for reference):
-```bash
-#crontab -e
-*/4 * * * * cd $HOME/bridge-monitor; node checkWorker.js >>cronWorker.out 2>>cronWorker.err
-*/5 * * * * cd $HOME/bridge-monitor; node checkWorker2.js >>cronWorker2.out 2>>cronWorker2.err
-```
 
 ## Linting
 

--- a/monitor/crontab.example
+++ b/monitor/crontab.example
@@ -1,2 +1,5 @@
-*/4 * * * * cd $HOME/bridge-monitor; node checkWorker.js >>cronWorker.out 2>>cronWorker.err
-*/5 * * * * cd $HOME/bridge-monitor; node checkWorker2.js >>cronWorker2.out 2>>cronWorker2.err
+# Yarn:
+*/4 * * * * cd $HOME/bridge-monitor; yarn check-all >>cronWorker.out 2>>cronWorker.err
+
+# Docker:
+*/4 * * * * cd $HOME/bridge-monitor; docker-compose exec monitor yarn check-all >>cronWorker.out 2>>cronWorker.err

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2.4'
+services:
+  monitor:
+    build:
+      context: ..
+      dockerfile: monitor/Dockerfile
+    ports:
+    - "${PORT}:${PORT}"
+    env_file: ./.env
+    environment: 
+      - NODE_ENV=production
+    restart: unless-stopped
+    entrypoint: yarn start

--- a/monitor/package.json
+++ b/monitor/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "check-all": "node checkWorker.js && node checkWorker2.js",
     "start": "node index.js",
     "lint": "eslint . --ignore-path ../.eslintignore",
     "lint:fix": "eslint . --fix"


### PR DESCRIPTION
- Fixes #77 
- Merged `checkWorker` `checkWorker2` scripts into one `yarn check-all script`
- Updated `crontab.example`
- Removed contents of `.env.example` and `crontab.example` from readme
    - My reasoning is that since we point out that these files are available for reference, there is no need to add contents to readme file - plus we avoid situation where we update a file and forget about the readme