### PR TITLE
Monitor - E2E

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,4 +124,27 @@ workflows:
   version: 2
   tokenbridge:
     jobs:
+      - initialize
+      - initialize-root:
+          filters:
+            branches:
+              only: master
+      - build:
+          requires:
+            - initialize
+      - lint:
+          requires:
+            - initialize
+      - test:
+          requires:
+            - initialize
+      - cover:
+          requires:
+            - initialize
+          filters:
+            branches:
+              only: master
+      - ansible-lint
+      - oracle-e2e
+      - ui-e2e
       - monitor-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,15 @@ jobs:
            paths:
              - ~/.cache/yarn
       - run: yarn run ui-e2e
+  monitor-e2e:
+    docker:
+      - image: circleci/node:10.15
+    steps:
+        - checkout
+        - run: git submodule update --init
+        - setup_remote_docker:
+            docker_layer_caching: true
+        - run: ./monitor-e2e/run-tests.sh
   cover:
     docker:
       - image: circleci/node:10.15
@@ -139,3 +148,4 @@ workflows:
       - ansible-lint
       - oracle-e2e
       - ui-e2e
+      - monitor-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,27 +125,4 @@ workflows:
   version: 2
   tokenbridge:
     jobs:
-      - initialize
-      - initialize-root:
-          filters:
-            branches:
-              only: master
-      - build:
-          requires:
-            - initialize
-      - lint:
-          requires:
-            - initialize
-      - test:
-          requires:
-            - initialize
-      - cover:
-          requires:
-            - initialize
-          filters:
-            branches:
-              only: master
-      - ansible-lint
-      - oracle-e2e
-      - ui-e2e
       - monitor-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,13 +105,12 @@ jobs:
              - ~/.cache/yarn
       - run: yarn run ui-e2e
   monitor-e2e:
-    docker:
-      - image: circleci/node:10.15
+    machine:
+      image: circleci/classic:latest
+      docker_layer_caching: true
     steps:
         - checkout
         - run: git submodule update --init
-        - setup_remote_docker:
-            docker_layer_caching: true
         - run: ./monitor-e2e/run-tests.sh
   cover:
     docker:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Sub-repositories maintained within this monorepo are listed below.
 | [Monitor](monitor/README.md) | Tool for checking balances and unprocessed events in bridged networks. |
 | [Deployment](deployment/README.md) | Ansible playbooks for deploying cross-chain bridges. |
 | [Oracle-E2E](oracle-e2e/README.md) | End to end tests for the Oracle |
+| [Monitor-E2E](monitor-e2e/README.md) | End to end tests for the Monitor |
 | [UI-E2E](ui-e2e/README.md) | End to end tests for the UI |
 | [E2E-Commons](e2e-commons/README.md) | Common utilities and configuration used in end to end tests |
 

--- a/e2e-commons/docker-compose.yml
+++ b/e2e-commons/docker-compose.yml
@@ -200,6 +200,8 @@ services:
     - LEFT_TX_THRESHOLD=100
     - PORT=3003
     entrypoint: yarn start
+    ports:
+    - "3003:3003"
   e2e:
     build:
       context: ..

--- a/e2e-commons/docker-compose.yml
+++ b/e2e-commons/docker-compose.yml
@@ -183,6 +183,23 @@ services:
     - REACT_APP_FOREIGN_GAS_PRICE_UPDATE_INTERVAL=15000
     - PORT=3000
     command: "true"
+  monitor:
+    build:
+      context: ..
+      dockerfile: monitor/Dockerfile
+    environment:
+    - HOME_RPC_URL=http://parity1:8545
+    - FOREIGN_RPC_URL=http://parity2:8545
+    - HOME_BRIDGE_ADDRESS=0x32198D570fffC7033641F8A9094FFDCaAEF42624
+    - FOREIGN_BRIDGE_ADDRESS=0x2B6871b9B02F73fa24F4864322CdC78604207769
+    - HOME_DEPLOYMENT_BLOCK=0
+    - FOREIGN_DEPLOYMENT_BLOCK=0
+    - GAS_PRICE_SPEED_TYPE=standard
+    - GAS_LIMIT=300000
+    - GAS_PRICE_FALLBACK=21
+    - LEFT_TX_THRESHOLD=100
+    - PORT=3003
+    entrypoint: yarn start
   e2e:
     build:
       context: ..

--- a/e2e-commons/up.sh
+++ b/e2e-commons/up.sh
@@ -40,7 +40,7 @@ while [ "$1" != "" ]; do
   fi
 
   if [ "$1" == "monitor" ]; then
-    docker-compose up -d -p 3003:3003 monitor
+    docker-compose up -d monitor
   fi
 
   shift # Shift all the parameters down by one

--- a/e2e-commons/up.sh
+++ b/e2e-commons/up.sh
@@ -40,7 +40,7 @@ while [ "$1" != "" ]; do
   fi
 
   if [ "$1" == "monitor" ]; then
-    docker-compose up -d monitor
+    docker-compose up -d -p 3003:3003 monitor
   fi
 
   shift # Shift all the parameters down by one

--- a/e2e-commons/up.sh
+++ b/e2e-commons/up.sh
@@ -39,5 +39,9 @@ while [ "$1" != "" ]; do
     node ./scripts/blocks.js &
   fi
 
+  if [ "$1" == "monitor" ]; then
+    docker-compose up -d monitor
+  fi
+
   shift # Shift all the parameters down by one
 done

--- a/monitor-e2e/README.md
+++ b/monitor-e2e/README.md
@@ -1,0 +1,11 @@
+# POA Token Bridge / Monitor-E2E
+
+End to end tests for the POA Token Bridge [Monitor](../monitor/README.md).
+
+## Running
+
+To run the bridge end-to-end tests, you just have to run:
+
+```
+./run-tests.sh
+```

--- a/monitor-e2e/run-tests.sh
+++ b/monitor-e2e/run-tests.sh
@@ -29,37 +29,30 @@ check_files_exist() {
 
 ##### Test cases #####
 
-# Test case - CheckWorker scripts should work and create files in responses/ directory
-
+echo "Test case - CheckWorker scripts should work and create files in responses/ directory"
 ! check_files_exist
-
 docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "node checkWorker.js"
 docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "node checkWorker2.js"
-
 check_files_exist
 
-# Test case - Web Interface should return balances
-
+echo "Test case - Web Interface should return balances"
 OUTPUT=$(curl -s http://localhost:3003/)
 grep -q home <<< "$OUTPUT"
 grep -q foreign <<< "$OUTPUT"
 ! grep -q error <<< "$OUTPUT"
 
-# Test case - Web Interface should return validators
-
+echo "Test case - Web Interface should return validators"
 OUTPUT=$(curl -s http://localhost:3003/validators)
 grep -q home <<< "$OUTPUT"
 grep -q foreign <<< "$OUTPUT"
 ! grep -q error <<< "$OUTPUT"
 
-# Test case - Web Interface should return eventsStats
-
+echo "Test case - Web Interface should return eventsStats"
 OUTPUT=$(curl -s http://localhost:3003/eventsStats)
 grep -q lastChecked <<< "$OUTPUT"
 ! grep -q error <<< "$OUTPUT"
 
-# Test case - Web Interface should return alerts
-
+echo "Test case - Web Interface should return alerts"
 OUTPUT=$(curl -s http://localhost:3003/alerts)
 grep -q lastChecked <<< "$OUTPUT"
 ! grep -q error <<< "$OUTPUT"

--- a/monitor-e2e/run-tests.sh
+++ b/monitor-e2e/run-tests.sh
@@ -30,7 +30,7 @@ check_files_exist() {
 ##### Test cases #####
 
 echo "Test case - CheckWorker scripts should work and create files in responses/ directory"
-! check_files_exist
+(! check_files_exist)
 docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "node checkWorker.js"
 docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "node checkWorker2.js"
 check_files_exist
@@ -39,23 +39,23 @@ echo "Test case - Web Interface should return balances"
 OUTPUT=$(curl -s http://localhost:3003/)
 grep -q home <<< "$OUTPUT"
 grep -q foreign <<< "$OUTPUT"
-! grep -q error <<< "$OUTPUT"
+(! grep -q error <<< "$OUTPUT")
 
 echo "Test case - Web Interface should return validators"
 OUTPUT=$(curl -s http://localhost:3003/validators)
 grep -q home <<< "$OUTPUT"
 grep -q foreign <<< "$OUTPUT"
-! grep -q error <<< "$OUTPUT"
+(! grep -q error <<< "$OUTPUT")
 
 echo "Test case - Web Interface should return eventsStats"
 OUTPUT=$(curl -s http://localhost:3003/eventsStats)
 grep -q lastChecked <<< "$OUTPUT"
-! grep -q error <<< "$OUTPUT"
+(! grep -q error <<< "$OUTPUT")
 
 echo "Test case - Web Interface should return alerts"
 OUTPUT=$(curl -s http://localhost:3003/alerts)
 grep -q lastChecked <<< "$OUTPUT"
-! grep -q error <<< "$OUTPUT"
+(! grep -q error <<< "$OUTPUT")
 
 
 ##### Cleanup #####

--- a/monitor-e2e/run-tests.sh
+++ b/monitor-e2e/run-tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+cd $(dirname $0)
+
+../e2e-commons/up.sh oracle deploy monitor
+
+FILES=(getBalances.json validators.json eventsStats.json alerts.json)
+
+check_files_exist() {
+  rc=0
+  for f in "${FILES[@]}"; do
+    command="test -f responses/$f"
+    (docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "$command") || rc=1
+  done
+  return $rc
+}
+
+! check_files_exist
+rc1=$?
+
+docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "node checkWorker.js"
+docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "node checkWorker2.js"
+
+check_files_exist
+rc2=$?
+
+../e2e-commons/down.sh
+[[ $rc1 -eq 0 && $rc2 -eq 0 ]] || exit 1

--- a/monitor-e2e/run-tests.sh
+++ b/monitor-e2e/run-tests.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 cd $(dirname $0)
+set -e # exit when any command fails
 
-../e2e-commons/up.sh oracle deploy monitor
+##### Helper Functions #####
+
+function cleanup {
+  echo "The tests failed, cleaning up..."
+  ../e2e-commons/down.sh
+}
+trap finish EXIT
 
 FILES=(getBalances.json validators.json eventsStats.json alerts.json)
 
@@ -14,14 +21,25 @@ check_files_exist() {
   return $rc
 }
 
+##### Initialization #####
+
+../e2e-commons/up.sh oracle deploy monitor
+
+# Test case - CheckWorker scripts should work and create files in responses/ directory
+
 ! check_files_exist
-rc1=$?
 
 docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "node checkWorker.js"
 docker-compose -f ../e2e-commons/docker-compose.yml exec monitor /bin/bash -c "node checkWorker2.js"
 
 check_files_exist
-rc2=$?
 
-../e2e-commons/down.sh
-[[ $rc1 -eq 0 && $rc2 -eq 0 ]] || exit 1
+# Test case - Web Interface should return balances
+
+#curl
+
+# Test case - Web Interface should return validators
+
+# Test case - Web Interface should return eventsStats
+
+# Test case - Web Interface should return alerts

--- a/monitor-e2e/run-tests.sh
+++ b/monitor-e2e/run-tests.sh
@@ -2,13 +2,13 @@
 cd $(dirname $0)
 set -e # exit when any command fails
 
+
 ##### Helper Functions #####
 
 function cleanup {
-  echo "The tests failed, cleaning up..."
   ../e2e-commons/down.sh
 }
-trap finish EXIT
+trap cleanup EXIT
 
 FILES=(getBalances.json validators.json eventsStats.json alerts.json)
 
@@ -21,9 +21,13 @@ check_files_exist() {
   return $rc
 }
 
+
 ##### Initialization #####
 
 ../e2e-commons/up.sh oracle deploy monitor
+
+
+##### Test cases #####
 
 # Test case - CheckWorker scripts should work and create files in responses/ directory
 
@@ -43,3 +47,8 @@ check_files_exist
 # Test case - Web Interface should return eventsStats
 
 # Test case - Web Interface should return alerts
+
+
+##### Cleanup #####
+
+cleanup

--- a/monitor-e2e/run-tests.sh
+++ b/monitor-e2e/run-tests.sh
@@ -40,13 +40,29 @@ check_files_exist
 
 # Test case - Web Interface should return balances
 
-#curl
+OUTPUT=$(curl http://localhost:3003/)
+grep -q home <<< "$OUTPUT"
+grep -q foreign <<< "$OUTPUT"
+! grep -q error <<< "$OUTPUT"
 
 # Test case - Web Interface should return validators
 
+OUTPUT=$(curl http://localhost:3003/validators)
+grep -q home <<< "$OUTPUT"
+grep -q foreign <<< "$OUTPUT"
+! grep -q error <<< "$OUTPUT"
+
 # Test case - Web Interface should return eventsStats
 
+OUTPUT=$(curl http://localhost:3003/eventsStats)
+grep -q lastChecked <<< "$OUTPUT"
+! grep -q error <<< "$OUTPUT"
+
 # Test case - Web Interface should return alerts
+
+OUTPUT=$(curl http://localhost:3003/alerts)
+grep -q lastChecked <<< "$OUTPUT"
+! grep -q error <<< "$OUTPUT"
 
 
 ##### Cleanup #####

--- a/monitor-e2e/run-tests.sh
+++ b/monitor-e2e/run-tests.sh
@@ -40,27 +40,27 @@ check_files_exist
 
 # Test case - Web Interface should return balances
 
-OUTPUT=$(curl http://localhost:3003/)
+OUTPUT=$(curl -s http://localhost:3003/)
 grep -q home <<< "$OUTPUT"
 grep -q foreign <<< "$OUTPUT"
 ! grep -q error <<< "$OUTPUT"
 
 # Test case - Web Interface should return validators
 
-OUTPUT=$(curl http://localhost:3003/validators)
+OUTPUT=$(curl -s http://localhost:3003/validators)
 grep -q home <<< "$OUTPUT"
 grep -q foreign <<< "$OUTPUT"
 ! grep -q error <<< "$OUTPUT"
 
 # Test case - Web Interface should return eventsStats
 
-OUTPUT=$(curl http://localhost:3003/eventsStats)
+OUTPUT=$(curl -s http://localhost:3003/eventsStats)
 grep -q lastChecked <<< "$OUTPUT"
 ! grep -q error <<< "$OUTPUT"
 
 # Test case - Web Interface should return alerts
 
-OUTPUT=$(curl http://localhost:3003/alerts)
+OUTPUT=$(curl -s http://localhost:3003/alerts)
 grep -q lastChecked <<< "$OUTPUT"
 ! grep -q error <<< "$OUTPUT"
 


### PR DESCRIPTION
Introduces end-to-end tests for the Monitor.

#### Coverage
The test cases cover basic integration and sanity checks:
- CheckWorker scripts work
- The endpoints are working and serving data on localhost

Closes #12 - I suggest we create a follow-up issue if we want to add more detailed test cases.

#### Bash script
The test cases were simple enough to fit into the `run-tests.sh` script. In case we add more detailed test cases it will probably make sense to add JavaScript tests like in `ui-e2e` and `oracle-e2e`.

#### Caveats for reference
- The executor of `monitor-e2e` job  is `machine`, because CircleCI `docker` executor, when using docker-in-docker, sets up a remote docker machine so `localhost:3003` does not simply work.
    [Docs](https://circleci.com/docs/2.0/building-docker-images/#accessing-services)