### PR TITLE
Deployment testing specific branch

### DIFF
--- a/deployment/TESTING.md
+++ b/deployment/TESTING.md
@@ -11,6 +11,22 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Push remote branch
+
+The deployment playbooks are cloning the monorepository on target hosts, using your current local git branch name. If the branch does not exists on remote, you need to push it.
+
+```
+git push
+```
+
+Alternatively, if there are no changes except the playbooks, you can use the `master` branch:
+
+```
+CIRCLE_BRANCH=master molecule test
+```
+
+In this case `master` branch will be used as a codebase for Monitor, UI, Oracle and Contracts deployed by your local playbook.
+
 ## Run the tests
 
 ```

--- a/deployment/molecule/default/molecule.yml
+++ b/deployment/molecule/default/molecule.yml
@@ -30,6 +30,7 @@ provisioner:
       oracle-host:
         VALIDATOR_ADDRESS_PRIVATE_KEY: "8e829f695aed89a154550f30262f1529582cc49dc30eff74a6b491359e0230f9" 
         syslog_server_port: "udp://127.0.0.1:514"
+        bridge_repo_branch: ${CIRCLE_BRANCH-$(git symbolic-ref --short HEAD)}
 verifier:
   name: testinfra
   lint:


### PR DESCRIPTION
Closes #119 

The default `bridge_repo_branch` is `master`.
This PR overrides it with:
- `$CIRCLE_BRANCH` - on CI
- `$(git symbolic-ref --short HEAD)` - current local git branch

#### Caveat
If I'm developing on local branch `branch-x`, the playbook will not be able to `git clone` on target-host because `branch-x` does not exist on remote - that's why I added a section in readme about pushing.