### PR TITLE
Oracle-E2E using Commons

### DIFF
--- a/oracle-e2e/config.json
+++ b/oracle-e2e/config.json
@@ -1,3 +1,0 @@
-{
-  "abiPath": "../contracts/build/contracts"
-}

--- a/oracle-e2e/test/ercToErc.js
+++ b/oracle-e2e/test/ercToErc.js
@@ -1,12 +1,9 @@
-const path = require('path')
 const Web3 = require('web3')
 const assert = require('assert')
 const promiseRetry = require('promise-retry')
 const { user, ercToErcBridge, homeRPC, foreignRPC } = require('../../e2e-commons/constants.json')
-const { abiPath } = require('../config.json')
+const { ERC677_BRIDGE_TOKEN_ABI } = require('../../commons')
 const { generateNewBlock } = require('../../e2e-commons/utils')
-
-const abisDir = path.join(__dirname, '..', abiPath)
 
 const homeWeb3 = new Web3(new Web3.providers.HttpProvider(homeRPC.URL))
 const foreignWeb3 = new Web3(new Web3.providers.HttpProvider(foreignRPC.URL))
@@ -19,9 +16,11 @@ const { toBN } = foreignWeb3.utils
 homeWeb3.eth.accounts.wallet.add(user.privateKey)
 foreignWeb3.eth.accounts.wallet.add(user.privateKey)
 
-const tokenAbi = require(path.join(abisDir, 'ERC677BridgeToken.json')).abi
-const erc20Token = new foreignWeb3.eth.Contract(tokenAbi, ercToErcBridge.foreignToken)
-const erc677Token = new homeWeb3.eth.Contract(tokenAbi, ercToErcBridge.homeToken)
+const erc20Token = new foreignWeb3.eth.Contract(
+  ERC677_BRIDGE_TOKEN_ABI,
+  ercToErcBridge.foreignToken
+)
+const erc677Token = new homeWeb3.eth.Contract(ERC677_BRIDGE_TOKEN_ABI, ercToErcBridge.homeToken)
 
 describe('erc to erc', () => {
   it('should convert tokens in foreign to tokens in home', async () => {

--- a/oracle-e2e/test/ercToNative.js
+++ b/oracle-e2e/test/ercToNative.js
@@ -1,12 +1,9 @@
-const path = require('path')
 const Web3 = require('web3')
 const assert = require('assert')
 const promiseRetry = require('promise-retry')
 const { user, ercToNativeBridge, homeRPC, foreignRPC } = require('../../e2e-commons/constants.json')
-const { abiPath } = require('../config.json')
+const { ERC677_BRIDGE_TOKEN_ABI } = require('../../commons')
 const { generateNewBlock } = require('../../e2e-commons/utils')
-
-const abisDir = path.join(__dirname, '..', abiPath)
 
 const homeWeb3 = new Web3(new Web3.providers.HttpProvider(homeRPC.URL))
 const foreignWeb3 = new Web3(new Web3.providers.HttpProvider(foreignRPC.URL))
@@ -19,8 +16,10 @@ const { toBN } = foreignWeb3.utils
 homeWeb3.eth.accounts.wallet.add(user.privateKey)
 foreignWeb3.eth.accounts.wallet.add(user.privateKey)
 
-const tokenAbi = require(path.join(abisDir, 'ERC677BridgeToken.json')).abi
-const erc20Token = new foreignWeb3.eth.Contract(tokenAbi, ercToNativeBridge.foreignToken)
+const erc20Token = new foreignWeb3.eth.Contract(
+  ERC677_BRIDGE_TOKEN_ABI,
+  ercToNativeBridge.foreignToken
+)
 
 describe('erc to native', () => {
   it('should convert tokens in foreign to coins in home', async () => {

--- a/oracle-e2e/test/nativeToErc.js
+++ b/oracle-e2e/test/nativeToErc.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const Web3 = require('web3')
 const assert = require('assert')
 const promiseRetry = require('promise-retry')
@@ -10,10 +9,9 @@ const {
   homeRPC,
   foreignRPC
 } = require('../../e2e-commons/constants.json')
-const { abiPath } = require('../config.json')
+const { ERC677_BRIDGE_TOKEN_ABI } = require('../../commons')
 const { generateNewBlock } = require('../../e2e-commons/utils')
 
-const abisDir = path.join(__dirname, '..', abiPath)
 const homeWeb3 = new Web3(new Web3.providers.HttpProvider(homeRPC.URL))
 const foreignWeb3 = new Web3(new Web3.providers.HttpProvider(foreignRPC.URL))
 const { toBN } = foreignWeb3.utils
@@ -28,8 +26,7 @@ foreignWeb3.eth.accounts.wallet.add(user.privateKey)
 foreignWeb3.eth.accounts.wallet.add(validator.privateKey)
 foreignWeb3.eth.accounts.wallet.add(secondUser.privateKey)
 
-const tokenAbi = require(path.join(abisDir, 'ERC677BridgeToken.json')).abi
-const token = new foreignWeb3.eth.Contract(tokenAbi, nativeToErcBridge.foreignToken)
+const token = new foreignWeb3.eth.Contract(ERC677_BRIDGE_TOKEN_ABI, nativeToErcBridge.foreignToken)
 
 const sleep = timeout => new Promise(res => setTimeout(res, timeout))
 


### PR DESCRIPTION
- Next step of #8 
- Replaced all references to ABIs with `Commons`
- Removed now-redundant `config.json`