### PR TITLE
Building containers in deployment

### DIFF
--- a/deployment/roles/monitor/tasks/jumpbox.yml
+++ b/deployment/roles/monitor/tasks/jumpbox.yml
@@ -1,5 +1,5 @@
 ---
-- name: Launch container
-  shell: docker-compose up -d
+- name: Build the containers
+  shell: docker-compose build
   args:
     chdir: "{{ bridge_path }}/monitor"

--- a/deployment/roles/monitor/tasks/servinstall.yml
+++ b/deployment/roles/monitor/tasks/servinstall.yml
@@ -9,9 +9,12 @@
     owner: root
     mode: 755
 
-- name: "Start/Enable the service"
+- name: "Enable the service"
   service:
     name: "tokenbridge-monitor"
     state: started
     enabled: yes
     use: service
+
+- name: Start the service
+  shell: service tokenbridge-monitor start

--- a/deployment/roles/oracle/tasks/jumpbox.yml
+++ b/deployment/roles/oracle/tasks/jumpbox.yml
@@ -1,5 +1,5 @@
 ---
-- name: Launch container
-  shell: docker-compose up -d
+- name: Build the containers
+  shell: docker-compose build
   args:
     chdir: "{{ bridge_path }}/oracle"

--- a/deployment/roles/oracle/tasks/servinstall.yml
+++ b/deployment/roles/oracle/tasks/servinstall.yml
@@ -9,9 +9,12 @@
     owner: root
     mode: 755
 
-- name: "Start/Enable poabridge service"
+- name: "Enable the service"
   service:
     name: "poabridge"
     state: started
     enabled: yes
     use: service
+
+- name: Start the service
+  shell: service poabridge start

--- a/deployment/roles/ui/tasks/jumpbox.yml
+++ b/deployment/roles/ui/tasks/jumpbox.yml
@@ -1,5 +1,5 @@
 ---
-- name: Launch container
-  shell: docker-compose up -d
+- name: Build the containers
+  shell: docker-compose build
   args:
     chdir: "{{ bridge_path }}/ui"

--- a/deployment/roles/ui/tasks/servinstall.yml
+++ b/deployment/roles/ui/tasks/servinstall.yml
@@ -9,9 +9,12 @@
     owner: root
     mode: 755
 
-- name: "Start/Enable the service"
+- name: "Enable the service"
   service:
     name: "tokenbridge-ui"
     state: started
     enabled: yes
     use: service
+
+- name: Start the service
+  shell: service tokenbridge-ui start


### PR DESCRIPTION
- Side-effect when working on #121 

The `jumpbox` task starts the services (Monitor, UI, Oracle) using `docker-compose up`.

Then given service is stopped, and started again in `servinstall`.
So it probably makes sense to only build the containers in `jumpbox`.