### PR TITLE
Remove default syslog server port

### DIFF
--- a/deployment/roles/oracle/defaults/main.yml
+++ b/deployment/roles/oracle/defaults/main.yml
@@ -3,5 +3,4 @@ bridge_path: "/home/{{ compose_service_user }}/bridge"
 ALLOW_HTTP: no
 QUEUE_URL: amqp://rabbit
 REDIS_URL: redis://redis
-syslog_server_port: udp://127.0.0.1:514
 keyfile_path: "/root/.key"


### PR DESCRIPTION
Having this default is against our documentation: 
![Screenshot 2019-07-16 at 15 07 18](https://user-images.githubusercontent.com/12039224/61296945-74288600-a7db-11e9-81b2-f6b23b559fbf.png)

..which implies that if you do not set this parameter, the remote logging is not default. Right now it is not the case because we have this default and the playbook sets up remote logging always, if I am not mistaken.
