### PR TITLE
Creating redis and rabbit with oracle

### DIFF
--- a/e2e-commons/up.sh
+++ b/e2e-commons/up.sh
@@ -4,11 +4,11 @@ set -e # exit when any command fails
 
 ./down.sh
 docker-compose build
-docker-compose up -d parity1 parity2 redis rabbit e2e
+docker-compose up -d parity1 parity2 e2e
 
 while [ "$1" != "" ]; do
   if [ "$1" == "oracle" ]; then
-    docker-compose up -d oracle oracle-erc20 oracle-erc20-native
+    docker-compose up -d redis rabbit oracle oracle-erc20 oracle-erc20-native
 
     docker-compose run -d oracle yarn watcher:signature-request
     docker-compose run -d oracle yarn watcher:collected-signatures


### PR DESCRIPTION
Came up when working on #121 

Redis and Rabbit are part of Oracle, so it makes sense to move creating those under `if [ "$1" == "oracle" ]` conditional.