### PR TITLE
Ability to override constant RPC urls in oracle-e2e

### DIFF
--- a/oracle-e2e/test/ercToErc.js
+++ b/oracle-e2e/test/ercToErc.js
@@ -5,8 +5,10 @@ const { user, ercToErcBridge, homeRPC, foreignRPC } = require('../../e2e-commons
 const { ERC677_BRIDGE_TOKEN_ABI } = require('../../commons')
 const { generateNewBlock } = require('../../e2e-commons/utils')
 
-const homeWeb3 = new Web3(new Web3.providers.HttpProvider(homeRPC.URL))
-const foreignWeb3 = new Web3(new Web3.providers.HttpProvider(foreignRPC.URL))
+const homeWeb3 = new Web3(new Web3.providers.HttpProvider(process.env.HOME_RPC || homeRPC.URL))
+const foreignWeb3 = new Web3(
+  new Web3.providers.HttpProvider(process.env.FOREIGN_RPC || foreignRPC.URL)
+)
 
 const HOME_BRIDGE_ADDRESS = ercToErcBridge.home
 const FOREIGN_BRIDGE_ADDRESS = ercToErcBridge.foreign

--- a/oracle-e2e/test/ercToNative.js
+++ b/oracle-e2e/test/ercToNative.js
@@ -5,8 +5,10 @@ const { user, ercToNativeBridge, homeRPC, foreignRPC } = require('../../e2e-comm
 const { ERC677_BRIDGE_TOKEN_ABI } = require('../../commons')
 const { generateNewBlock } = require('../../e2e-commons/utils')
 
-const homeWeb3 = new Web3(new Web3.providers.HttpProvider(homeRPC.URL))
-const foreignWeb3 = new Web3(new Web3.providers.HttpProvider(foreignRPC.URL))
+const homeWeb3 = new Web3(new Web3.providers.HttpProvider(process.env.HOME_RPC || homeRPC.URL))
+const foreignWeb3 = new Web3(
+  new Web3.providers.HttpProvider(process.env.FOREIGN_RPC || foreignRPC.URL)
+)
 
 const HOME_BRIDGE_ADDRESS = ercToNativeBridge.home
 const FOREIGN_BRIDGE_ADDRESS = ercToNativeBridge.foreign

--- a/oracle-e2e/test/nativeToErc.js
+++ b/oracle-e2e/test/nativeToErc.js
@@ -12,8 +12,11 @@ const {
 const { ERC677_BRIDGE_TOKEN_ABI } = require('../../commons')
 const { generateNewBlock } = require('../../e2e-commons/utils')
 
-const homeWeb3 = new Web3(new Web3.providers.HttpProvider(homeRPC.URL))
-const foreignWeb3 = new Web3(new Web3.providers.HttpProvider(foreignRPC.URL))
+const homeWeb3 = new Web3(new Web3.providers.HttpProvider(process.env.HOME_RPC || homeRPC.URL))
+const foreignWeb3 = new Web3(
+  new Web3.providers.HttpProvider(process.env.FOREIGN_RPC || foreignRPC.URL)
+)
+
 const { toBN } = foreignWeb3.utils
 
 const HOME_BRIDGE_ADDRESS = nativeToErcBridge.home


### PR DESCRIPTION
Done in preparation for #121 , where the RPCs will be different from what we have in our constants.