### PR TITLE
First step of ultimate e2e testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,34 +134,10 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - run:
-          name: Install node
-          command: |
-            set +e             
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm install v10.15.3
-
-            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-            echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-      - run: 
-          name: Install yarn
-          command: |
-            nvm use v10.15.3
-            curl -o- -L https://yarnpkg.com/install.sh | bash
-            echo 'export PATH=$HOME/.yarn/bin:$PATH' >> $BASH_ENV
-            source $BASH_ENV
-      - run: 
-          name: initialize
-          command: |
-            nvm use v10.15.3
-            yarn run initialize
+      - run: git submodule update --init
       - run:
           name: Prepare the infrastructure
-          command: |
-            nvm use v10.15.3
-            e2e-commons/up.sh deploy native-to-erc
+          command: e2e-commons/up.sh deploy native-to-erc
       - run: 'echo "TODO - Run the e2e tests on top of the infrastructure created by previous step"'
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,37 @@ jobs:
     steps:
       - checkout
       - run: deployment/molecule/molecule.sh ui
+  ultimate-native-to-erc:
+    machine:
+      image: circleci/classic:latest
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Install node
+          command: |
+            set +e             
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm install v10.15.3
+
+            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+            echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+      - run: 
+          name: Install yarn
+          command: |
+            nvm use v10.15.3
+            curl -o- -L https://yarnpkg.com/install.sh | bash
+            echo 'export PATH=$HOME/.yarn/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+            yarn run initialize
+      - run:
+          name: Prepare the infrastructure
+          command: |
+            nvm use v10.15.3
+            e2e-commons/up.sh deploy native-to-erc
+      - run: 'echo "TODO - Run the e2e tests on top of the infrastructure created by previous step"'
 workflows:
   version: 2
   tokenbridge:
@@ -157,3 +188,4 @@ workflows:
       - monitor-e2e
       - deployment-oracle
       - deployment-ui
+      - ultimate-native-to-erc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,10 @@ jobs:
             curl -o- -L https://yarnpkg.com/install.sh | bash
             echo 'export PATH=$HOME/.yarn/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
+      - run: 
+          name: initialize
+          command: |
+            nvm use v10.15.3
             yarn run initialize
       - run:
           name: Prepare the infrastructure

--- a/deployment/molecule/molecule.sh
+++ b/deployment/molecule/molecule.sh
@@ -3,9 +3,10 @@ cd $(dirname $0)
 set -e # exit when any command fails
 
 CODEBASE_BRANCH=${CIRCLE_BRANCH-$(git symbolic-ref --short HEAD)}
+DOCKER_LOCALHOST=${DOCKER_LOCALHOST-localhost}
 
 while [ "$1" != "" ]; do
-  docker-compose build && docker-compose run -e CODEBASE_BRANCH=$CODEBASE_BRANCH molecule_runner /bin/bash -c "molecule test --scenario-name $1"
+  docker-compose build && docker-compose run -e CODEBASE_BRANCH=$CODEBASE_BRANCH -e DOCKER_LOCALHOST=$DOCKER_LOCALHOST molecule_runner /bin/bash -c "molecule test --scenario-name $1"
 
   shift # Shift all the parameters down by one
 done

--- a/deployment/molecule/ultimate-native-to-erc/Dockerfile.j2
+++ b/deployment/molecule/ultimate-native-to-erc/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/deployment/molecule/ultimate-native-to-erc/molecule.yml
+++ b/deployment/molecule/ultimate-native-to-erc/molecule.yml
@@ -1,0 +1,47 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: oracle-native-to-erc-host
+    groups:
+      - example
+    children:
+      - oracle
+    image: ubuntu:16.04
+    privileged: true
+    network_mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../prepare.yml
+    converge: ../../site.yml
+  inventory:
+    host_vars:
+      oracle-native-to-erc-host:
+        bridge_repo_branch: $CODEBASE_BRANCH
+        VALIDATOR_ADDRESS: "0xaaB52d66283F7A1D5978bcFcB55721ACB467384b"
+        VALIDATOR_ADDRESS_PRIVATE_KEY: "8e829f695aed89a154550f30262f1529582cc49dc30eff74a6b491359e0230f9"
+        HOME_BRIDGE_ADDRESS: "0x32198D570fffC7033641F8A9094FFDCaAEF42624"
+        FOREIGN_BRIDGE_ADDRESS: "0x2B6871b9B02F73fa24F4864322CdC78604207769"
+        ERC20_TOKEN_ADDRESS: "0xdbeE25CbE97e4A5CC6c499875774dc7067E9426B"
+        QUEUE_URL: "amqp://$DOCKER_LOCALHOST"
+        REDIS_URL: "redis://$DOCKER_LOCALHOST:6379"
+        HOME_RPC_URL: "http://$DOCKER_LOCALHOST:8541"
+        FOREIGN_RPC_URL: "http://$DOCKER_LOCALHOST:8542"
+        ALLOW_HTTP: yes
+        LOG_LEVEL: debug
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+scenario:
+  name: ultimate-native-to-erc
+  test_sequence:
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge

--- a/e2e-commons/README.md
+++ b/e2e-commons/README.md
@@ -24,3 +24,4 @@ Shut down and cleans up containers, networks, services, running scripts:
 | oracle | Launches Oracle containers |
 | ui | Launches UI containers |
 | blocks | Auto mines blocks |
+| native-to-erc | Creates infrastructure for ultimate e2e testing, for native-to-erc type of bridge |

--- a/e2e-commons/up.sh
+++ b/e2e-commons/up.sh
@@ -49,7 +49,7 @@ while [ "$1" != "" ]; do
   fi
 
   if [ "$1" == "native-to-erc" ]; then
-    deployment/molecule/molecule.sh ultimate-native-to-erc
+    ../deployment/molecule/molecule.sh ultimate-native-to-erc
   fi
 
   shift # Shift all the parameters down by one

--- a/e2e-commons/up.sh
+++ b/e2e-commons/up.sh
@@ -5,8 +5,13 @@ set -e # exit when any command fails
 ./down.sh
 docker-compose build
 docker-compose up -d parity1 parity2 e2e
+export DOCKER_LOCALHOST="localhost"
 
 while [ "$1" != "" ]; do
+  if [ "$1" == "macos" ]; then
+    export DOCKER_LOCALHOST="host.docker.internal"
+  fi
+
   if [ "$1" == "oracle" ]; then
     docker-compose up -d redis rabbit oracle oracle-erc20 oracle-erc20-native
 
@@ -41,6 +46,10 @@ while [ "$1" != "" ]; do
 
   if [ "$1" == "monitor" ]; then
     docker-compose up -d monitor
+  fi
+
+  if [ "$1" == "native-to-erc" ]; then
+    deployment/molecule/molecule.sh ultimate-native-to-erc
   fi
 
   shift # Shift all the parameters down by one


### PR DESCRIPTION
#### Purpose
The purpose of this PR is to add CI job and molecule scenario needed in #121 , in order to avoid huge PR.

#### Added
- Molecule scenario `ultimate-native-to-erc`
    - Used to spin up Oracle using our deployment playbook
- CI job, which:
    - Launches the `ultimate-native-to-erc` scenario
    - Launches `oracle-e2e` tests (left as a todo)

#### Comments
- The differences between Docker for Mac and linux Docker required me to add `DOCKER_LOCALHOST` variable
- The `QUEUE_URL`, `REDIS_URL`, `HOME_RPC_URL`, `FOREIGN_RPC_URL` have to be changed because the hostnames like `rabbit` or `parity1` do not work when using `network_mode: host`.
    - We have to use `network_mode: host` because otherwise the Oracle, deployed as a Docker-in-Docker, cannot access the Paritys
- The initial idea, as discussed on last call with @akolotov , was to change existing code in `e2e-commons/up.sh`. Now I think that it's better to add these tests side-by-side, potentially removing current e2e tests in the future.