### PR TITLE
add optional shift decimals

### DIFF
--- a/oracle/.env.example
+++ b/oracle/.env.example
@@ -31,6 +31,8 @@ FOREIGN_START_BLOCK=
 LOG_LEVEL=debug
 MAX_PROCESSING_TIME=20000
 
+FOREIGN_TO_HOME_DECIMAL_SHIFT=
+
 #Uncomment these lines only if you are going to send transaction by testing scripts
 #USER_ADDRESS=0x59c4474184579b9c31b5e51445b6eef91cebf370
 #USER_ADDRESS_PRIVATE_KEY=

--- a/oracle/src/events/processSignatureRequests/index.js
+++ b/oracle/src/events/processSignatureRequests/index.js
@@ -14,7 +14,7 @@ const {
 } = require('../../utils/errors')
 const { EXIT_CODES, MAX_CONCURRENT_EVENTS } = require('../../utils/constants')
 
-const { VALIDATOR_ADDRESS_PRIVATE_KEY ,FOREIGN_TO_HOME_DECIMAL_SHIFT } = process.env
+const { VALIDATOR_ADDRESS_PRIVATE_KEY, FOREIGN_TO_HOME_DECIMAL_SHIFT } = process.env
 
 const limit = promiseLimit(MAX_CONCURRENT_EVENTS)
 
@@ -49,12 +49,11 @@ function processSignatureRequestsBuilder(config) {
           eventTransactionHash: signatureRequest.transactionHash
         })
 
-
-        if(FOREIGN_TO_HOME_DECIMAL_SHIFT){
-          const foreignToHomeDecimalShift =new BN(FOREIGN_TO_HOME_DECIMAL_SHIFT)
-          if(!foreignToHomeDecimalShift.isZero()){
+        if (FOREIGN_TO_HOME_DECIMAL_SHIFT) {
+          const foreignToHomeDecimalShift = new BN(FOREIGN_TO_HOME_DECIMAL_SHIFT)
+          if (!foreignToHomeDecimalShift.isZero()) {
             logger.debug({ value }, `value will be negated shift by ${foreignToHomeDecimalShift} `)
-            value=new BN(value).shiftedBy(foreignToHomeDecimalShift.negated().toNumber())
+            value = new BN(value).shiftedBy(foreignToHomeDecimalShift.negated().toNumber())
             logger.debug({ value }, `new value shifted`)
           }
         }

--- a/oracle/src/events/processSignatureRequests/index.js
+++ b/oracle/src/events/processSignatureRequests/index.js
@@ -42,7 +42,8 @@ function processSignatureRequestsBuilder(config) {
     rootLogger.debug(`Processing ${signatureRequests.length} SignatureRequest events`)
     const callbacks = signatureRequests.map(signatureRequest =>
       limit(async () => {
-        let { recipient, value } = signatureRequest.returnValues
+        const { recipient } = signatureRequest.returnValues
+        let { value } = signatureRequest.returnValues
 
         const logger = rootLogger.child({
           eventTransactionHash: signatureRequest.transactionHash

--- a/oracle/src/events/processTransfers/index.js
+++ b/oracle/src/events/processTransfers/index.js
@@ -36,7 +36,8 @@ function processTransfersBuilder(config) {
     rootLogger.debug(`Processing ${transfers.length} Transfer events`)
     const callbacks = transfers.map(transfer =>
       limit(async () => {
-        let { from, value } = transfer.returnValues
+        const { from } = transfer.returnValues
+        let { value } = transfer.returnValues
 
         const logger = rootLogger.child({
           eventTransactionHash: transfer.transactionHash

--- a/oracle/src/events/processTransfers/index.js
+++ b/oracle/src/events/processTransfers/index.js
@@ -43,15 +43,14 @@ function processTransfersBuilder(config) {
           eventTransactionHash: transfer.transactionHash
         })
 
-        if(FOREIGN_TO_HOME_DECIMAL_SHIFT){
-          const foreignToHomeDecimalShift =new BN(FOREIGN_TO_HOME_DECIMAL_SHIFT)
-          if(!foreignToHomeDecimalShift.isZero()){
+        if (FOREIGN_TO_HOME_DECIMAL_SHIFT) {
+          const foreignToHomeDecimalShift = new BN(FOREIGN_TO_HOME_DECIMAL_SHIFT)
+          if (!foreignToHomeDecimalShift.isZero()) {
             logger.debug({ value }, `value will be shift by ${foreignToHomeDecimalShift} `)
-            value=new BN(value).shiftedBy(foreignToHomeDecimalShift.toNumber())
+            value = new BN(value).shiftedBy(foreignToHomeDecimalShift.toNumber())
             logger.debug({ value }, `new value shifted`)
           }
         }
-
 
         logger.info({ from, value }, `Processing transfer ${transfer.transactionHash}`)
 


### PR DESCRIPTION
Using the bridge in ERC20 to NATIVE mode, I need an decimals shift.
As the the ERC20 used is an 9 decimals token on foreign chain and I bridge it to a 18 decimals native on home chain. 
I need to shift by 9 decimals on one way and -9 in the other way. 

Here a PR of this optional FOREIGN_TO_HOME_DECIMAL_SHIFT in bridge config for that.

if FOREIGN_TO_HOME_DECIMAL_SHIFT is not set or equal to 0. It will not impact the current code.