### PR TITLE
Skip ui-e2e on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,11 @@ workflows:
             branches:
               only: master
       - oracle-e2e
-      - ui-e2e
+      - ui-e2e:
+          filters:
+            branches:
+              ignore:
+                - master
       - monitor-e2e
       - deployment-oracle
       - deployment-ui


### PR DESCRIPTION
We have a failing CI badge because of flaky `ui-e2e`.

![Screenshot 2019-07-31 at 10 13 16](https://user-images.githubusercontent.com/12039224/62195463-5a12aa00-b37c-11e9-82f2-6dad396830a8.png)


I propose we don't run them on master to avoid these false negatives.
The `ui-e2e` will still be run on every PR.