### PR TITLE
Simplify Molecule development

### DIFF
--- a/deployment/molecule/Dockerfile
+++ b/deployment/molecule/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.7-stretch
 RUN curl -fsSL https://get.docker.com | sh
 RUN pip3 install docker molecule==2.22rc1 molecule[docker] flake8
-WORKDIR runner
-COPY . .
+WORKDIR mono/deployment

--- a/deployment/molecule/docker-compose.yml
+++ b/deployment/molecule/docker-compose.yml
@@ -9,3 +9,4 @@ services:
     privileged: true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ../..:/mono


### PR DESCRIPTION
Instead of copying the files when building molecule docker image, it is better to just mount the host directory into the docker container.

That way, when developing/debugging molecule scenarios, there is no need to rebuild the docker image when there are changes  to molecule scenarios.