### PR TITLE
New way of deploying repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,16 +169,19 @@ jobs:
     executor: tokenbridge-orb/machine-with-docker-caching
     steps:
       - checkout
+      - run: git submodule update --init
       - run: deployment/molecule/molecule.sh oracle
   deployment-ui:
     executor: tokenbridge-orb/machine-with-docker-caching
     steps:
       - checkout
+      - run: git submodule update --init
       - run: deployment/molecule/molecule.sh ui
   deployment-monitor:
     executor: tokenbridge-orb/machine-with-docker-caching
     steps:
       - checkout
+      - run: git submodule update --init
       - run: deployment/molecule/molecule.sh monitor
   ultimate:
     executor: tokenbridge-orb/machine-with-docker-caching

--- a/deployment/CONFIGURATION.md
+++ b/deployment/CONFIGURATION.md
@@ -89,10 +89,6 @@ Example config for installing only UI:
 
 2.1 `compose_service_user` - specifies the user created by the playbooks. This user runs the TokenBridge Oracle.
 
-2.2 `bridge_repo` contains the address of the TokenBridge Oracle repository. The default value is https://github.com/poanetwork/tokenbridge.
-
-2.3 `bridge_repo_branch` points to the specific branch or commit to use with the `bridge_repo`. If `bridge_repo_branch` is not specified, the default (`master`) branch is used.
-
 2.4 `bridge_path` sets the path where the TokenBridge Oracle is installed. By default, it points. to the home folder of `compose_service_user`
 
 2.5 `docker_compose_version` - specifies a version of docker-compose to be installed.

--- a/deployment/molecule/Dockerfile
+++ b/deployment/molecule/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.7-stretch
+RUN apt-get install -y rsync
 RUN curl -fsSL https://get.docker.com | sh
 RUN pip3 install docker molecule==2.22rc1 molecule[docker] flake8
 WORKDIR mono/deployment

--- a/deployment/molecule/Dockerfile
+++ b/deployment/molecule/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7-stretch
-RUN apt-get install -y rsync
+RUN apt-get update && apt-get install -y rsync
 RUN curl -fsSL https://get.docker.com | sh
 RUN pip3 install docker molecule==2.22rc1 molecule[docker] flake8
 WORKDIR mono/deployment

--- a/deployment/molecule/molecule.sh
+++ b/deployment/molecule/molecule.sh
@@ -2,10 +2,8 @@
 cd $(dirname $0)
 set -e # exit when any command fails
 
-CODEBASE_BRANCH=${CIRCLE_BRANCH-$(git symbolic-ref --short HEAD)}
-
 while [ "$1" != "" ]; do
-  docker-compose build && docker-compose run -e CODEBASE_BRANCH=$CODEBASE_BRANCH molecule_runner /bin/bash -c "molecule test --scenario-name $1"
+  docker-compose build && docker-compose run molecule_runner /bin/bash -c "molecule test --scenario-name $1"
 
   shift # Shift all the parameters down by one
 done

--- a/deployment/molecule/monitor/molecule.yml
+++ b/deployment/molecule/monitor/molecule.yml
@@ -33,7 +33,6 @@ provisioner:
   inventory:
     host_vars:
       monitor-host:
-        bridge_repo_branch: $CODEBASE_BRANCH
         syslog_server_port: "udp://127.0.0.1:514"
 verifier:
   name: testinfra

--- a/deployment/molecule/oracle/molecule.yml
+++ b/deployment/molecule/oracle/molecule.yml
@@ -35,7 +35,6 @@ provisioner:
       oracle-host:
         VALIDATOR_ADDRESS_PRIVATE_KEY: "8e829f695aed89a154550f30262f1529582cc49dc30eff74a6b491359e0230f9"
         syslog_server_port: "udp://127.0.0.1:514"
-        bridge_repo_branch: $CODEBASE_BRANCH
 verifier:
   name: testinfra
   lint:

--- a/deployment/molecule/ui/molecule.yml
+++ b/deployment/molecule/ui/molecule.yml
@@ -34,7 +34,6 @@ provisioner:
     host_vars:
       ui-host:
         syslog_server_port: "udp://127.0.0.1:514"
-        bridge_repo_branch: $CODEBASE_BRANCH
 verifier:
   name: testinfra
   lint:

--- a/deployment/molecule/ultimate-erc-to-erc/molecule.yml
+++ b/deployment/molecule/ultimate-erc-to-erc/molecule.yml
@@ -32,13 +32,11 @@ provisioner:
   inventory:
     host_vars:
       oracle-erc-to-erc-host:
-        bridge_repo_branch: $CODEBASE_BRANCH
         HOME_RPC_URL: "http://parity1:8545"
         FOREIGN_RPC_URL: "http://parity2:8545"
         VALIDATOR_ADDRESS: "0xaaB52d66283F7A1D5978bcFcB55721ACB467384b"
         VALIDATOR_ADDRESS_PRIVATE_KEY: "8e829f695aed89a154550f30262f1529582cc49dc30eff74a6b491359e0230f9"
       ui-erc-to-erc-host:
-        bridge_repo_branch: $CODEBASE_BRANCH
         HOME_RPC_URL: "http://localhost:8541"
         FOREIGN_RPC_URL: "http://localhost:8542"
 verifier:

--- a/deployment/molecule/ultimate-erc-to-native/molecule.yml
+++ b/deployment/molecule/ultimate-erc-to-native/molecule.yml
@@ -32,13 +32,11 @@ provisioner:
   inventory:
     host_vars:
       oracle-erc-to-native-host:
-        bridge_repo_branch: $CODEBASE_BRANCH
         HOME_RPC_URL: "http://parity1:8545"
         FOREIGN_RPC_URL: "http://parity2:8545"
         VALIDATOR_ADDRESS: "0xaaB52d66283F7A1D5978bcFcB55721ACB467384b"
         VALIDATOR_ADDRESS_PRIVATE_KEY: "8e829f695aed89a154550f30262f1529582cc49dc30eff74a6b491359e0230f9"
       ui-erc-to-native-host:
-        bridge_repo_branch: $CODEBASE_BRANCH
         HOME_RPC_URL: "http://localhost:8541"
         FOREIGN_RPC_URL: "http://localhost:8542"
 verifier:

--- a/deployment/molecule/ultimate-native-to-erc/molecule.yml
+++ b/deployment/molecule/ultimate-native-to-erc/molecule.yml
@@ -32,13 +32,11 @@ provisioner:
   inventory:
     host_vars:
       oracle-native-to-erc-host:
-        bridge_repo_branch: $CODEBASE_BRANCH
         HOME_RPC_URL: "http://parity1:8545"
         FOREIGN_RPC_URL: "http://parity2:8545"
         VALIDATOR_ADDRESS: "0xaaB52d66283F7A1D5978bcFcB55721ACB467384b"
         VALIDATOR_ADDRESS_PRIVATE_KEY: "8e829f695aed89a154550f30262f1529582cc49dc30eff74a6b491359e0230f9"
       ui-native-to-erc-host:
-        bridge_repo_branch: $CODEBASE_BRANCH
         HOME_RPC_URL: "http://localhost:8541"
         FOREIGN_RPC_URL: "http://localhost:8542"
 verifier:

--- a/deployment/roles/common/defaults/main.yml
+++ b/deployment/roles/common/defaults/main.yml
@@ -2,5 +2,3 @@
 docker_compose_version: 1.23.2
 compose_service_user: poadocker
 bridge_path: "/home/{{ compose_service_user }}/bridge"
-bridge_repo: https://github.com/poanetwork/tokenbridge.git
-bridge_repo_branch: master

--- a/deployment/roles/common/tasks/dependencies.yml
+++ b/deployment/roles/common/tasks/dependencies.yml
@@ -22,6 +22,7 @@
     - git
     - python3
     - python3-pip
+    - rsync
 
 - name: Install Docker Compose
   get_url:

--- a/deployment/roles/common/tasks/repo.yml
+++ b/deployment/roles/common/tasks/repo.yml
@@ -8,5 +8,5 @@
     dest: "{{ bridge_path }}"
     src: ../../../..
     rsync_opts:
-      - "--cvs-exclude"
+      - "--exclude=.git"
       - "--exclude-from=../.gitignore"

--- a/deployment/roles/common/tasks/repo.yml
+++ b/deployment/roles/common/tasks/repo.yml
@@ -9,4 +9,4 @@
     src: ../../../..
     rsync_opts:
       - "--cvs-exclude"
-      - "--exclude-from=../../../.gitignore"
+      - "--exclude-from=../.gitignore"

--- a/deployment/roles/common/tasks/repo.yml
+++ b/deployment/roles/common/tasks/repo.yml
@@ -6,32 +6,20 @@
 
 - name: Register files for copying
   shell: |
-    git ls-tree -r HEAD --name-only > rsync_synchronize.tmp
-    cd contracts; git ls-tree -r HEAD --name-only > rsync_synchronize.tmp
+    git ls-tree -r HEAD --name-only
+    cd contracts; git ls-tree -r HEAD --name-only | sed -e 's/^/contracts\//'
+  register: rsync_files
   delegate_to: 127.0.0.1
   become: false
   args:
     chdir: ".."
 
-- name: Synchronize the monorepository
+- name: Copy the files
   synchronize:
     dest: "{{ bridge_path }}"
     src: ../../../..
     rsync_opts:
-      - "--files-from=../rsync_synchronize.tmp"
+      - "--include=\"{{ item }}\""
+      - "--exclude='*'"
       - "-avz"
-
-- name: Synchronize the submodules
-  synchronize:
-    dest: "{{ bridge_path }}/contracts"
-    src: ../../../../contracts
-    rsync_opts:
-      - "--files-from=../contracts/rsync_synchronize.tmp"
-      - "-avz"
-
-- name: Delete temporary files
-  shell: "rm rsync_synchronize.tmp contracts/rsync_synchronize.tmp"
-  delegate_to: 127.0.0.1
-  become: false
-  args:
-    chdir: ".."
+  with_items: rsync_files.stdout_lines

--- a/deployment/roles/common/tasks/repo.yml
+++ b/deployment/roles/common/tasks/repo.yml
@@ -3,10 +3,35 @@
   file: 
     path: "{{ bridge_path }}"
     state: directory
-- name: Synchronize the repository with current files
+
+- name: Register files for copying
+  shell: |
+    git ls-tree -r HEAD --name-only > rsync_synchronize.tmp
+    cd contracts; git ls-tree -r HEAD --name-only > rsync_synchronize.tmp
+  delegate_to: 127.0.0.1
+  become: false
+  args:
+    chdir: ".."
+
+- name: Synchronize the monorepository
   synchronize:
     dest: "{{ bridge_path }}"
     src: ../../../..
     rsync_opts:
-      - "--exclude=.git"
-      - "--exclude-from=../.gitignore"
+      - "--files-from=../rsync_synchronize.tmp"
+      - "-avz"
+
+- name: Synchronize the submodules
+  synchronize:
+    dest: "{{ bridge_path }}/contracts"
+    src: ../../../../contracts
+    rsync_opts:
+      - "--files-from=../contracts/rsync_synchronize.tmp"
+      - "-avz"
+
+- name: Delete temporary files
+  shell: "rm rsync_synchronize.tmp contracts/rsync_synchronize.tmp"
+  delegate_to: 127.0.0.1
+  become: false
+  args:
+    chdir: ".."

--- a/deployment/roles/common/tasks/repo.yml
+++ b/deployment/roles/common/tasks/repo.yml
@@ -1,12 +1,12 @@
 ---
-- name: Get bridge repo
-  git:
-    repo: "{{ bridge_repo }}"
+- name: Create repo directory
+  file: 
+    path: "{{ bridge_path }}"
+    state: directory
+- name: Synchronize the repository with current files
+  synchronize:
     dest: "{{ bridge_path }}"
-    force: no
-    update: no
-    version: "{{ bridge_repo_branch }}"
-- name: Initialize submodules
-  shell: git submodule update --init
-  args:
-    chdir: "{{ bridge_path }}"
+    src: ../../../..
+    rsync_opts:
+      - "--cvs-exclude"
+      - "--exclude-from=../../../.gitignore"


### PR DESCRIPTION
- Closes #167 by changing the task cloning the repository, to just copy the files
- Removed now-obsolete `bridge_repo` and `bridge_repo_branch` configs
- Note that this PR is a forked PR from `rzadp/tokenbridge`, demonstrating working tests
- Related PR: #194 

- [x] TODO: Manually test deployment on DigitalOcean