### PR TITLE
Update dpkg when installing chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ orbs:
     commands:
       install-chrome:
         steps:
+          - run:
+              name: Update dpkg
+              command: |
+                sudo apt-get clean
+                sudo apt-get update
+                sudo apt-get install dpkg
           - run: 
               name: Install Chrome
               command: |


### PR DESCRIPTION
Some dpkg errors started appearing when installing Chrome on CI jobs, the resolution seems to be just to [update dpkg](https://askubuntu.com/a/1100361) before attempting to install Chrome.

![Screenshot 2019-09-11 at 14 08 04](https://user-images.githubusercontent.com/12039224/64696064-d16c4b00-d49d-11e9-9b31-f713cf7f197f.png)
