### PR TITLE
ORACLE_LOG_LEVEL is not mandatory

### DIFF
--- a/deployment/roles/oracle/templates/.env.j2
+++ b/deployment/roles/oracle/templates/.env.j2
@@ -1,6 +1,8 @@
 ## General settings
 ORACLE_BRIDGE_MODE={{ ORACLE_BRIDGE_MODE }}
+{% if ORACLE_LOG_LEVEL | default('') != '' %}
 ORACLE_LOG_LEVEL={{ ORACLE_LOG_LEVEL }}
+{% endif %}
 
 ## Home contract
 COMMON_HOME_RPC_URL={{ COMMON_HOME_RPC_URL }}


### PR DESCRIPTION
`ORACLE_LOG_LEVEL` variable [doesn't seem to be mandatory](https://github.com/poanetwork/tokenbridge/blob/db89d1c12e27554394eea232a687efcfe35c3c09/oracle/src/services/logger.js#L9) but deployment playbook won't work if it isn't set.