### PR TITLE
Fix monitor path in crontab example

### DIFF
--- a/monitor/crontab.example
+++ b/monitor/crontab.example
@@ -1,5 +1,5 @@
 # Yarn:
-*/4 * * * * cd $HOME/bridge-monitor; yarn check-all >>cronWorker.out 2>>cronWorker.err
+*/4 * * * * cd $HOME/tokenbridge/monitor; yarn check-all >>cronWorker.out 2>>cronWorker.err
 
 # Docker:
-*/4 * * * * cd $HOME/bridge-monitor; docker-compose exec monitor yarn check-all >>cronWorker.out 2>>cronWorker.err
+*/4 * * * * cd $HOME/tokenbridge/monitor; docker-compose exec monitor yarn check-all >>cronWorker.out 2>>cronWorker.err


### PR DESCRIPTION
This is a minor PR which fixes path in crontab example for monorepo