### PR TITLE
Changes in initialization of array to iterate getting signatures

### DIFF
--- a/oracle/src/events/processAMBCollectedSignatures/index.js
+++ b/oracle/src/events/processAMBCollectedSignatures/index.js
@@ -47,6 +47,8 @@ function processCollectedSignaturesBuilder(config) {
         logger.info(`Processing CollectedSignatures ${colSignature.transactionHash}`)
         const message = await homeBridge.methods.message(messageHash).call()
 
+        logger.debug({ NumberOfCollectedSignatures }, 'Number of signatures to get')
+
         const requiredSignatures = []
         requiredSignatures.length = NumberOfCollectedSignatures
         requiredSignatures.fill(0)

--- a/oracle/src/events/processAMBCollectedSignatures/index.js
+++ b/oracle/src/events/processAMBCollectedSignatures/index.js
@@ -47,7 +47,9 @@ function processCollectedSignaturesBuilder(config) {
         logger.info(`Processing CollectedSignatures ${colSignature.transactionHash}`)
         const message = await homeBridge.methods.message(messageHash).call()
 
-        const requiredSignatures = new Array(NumberOfCollectedSignatures).fill(0)
+        const requiredSignatures = []
+        requiredSignatures.length = NumberOfCollectedSignatures
+        requiredSignatures.fill(0)
 
         const signaturesArray = []
         const [v, r, s] = [[], [], []]

--- a/oracle/src/events/processCollectedSignatures/index.js
+++ b/oracle/src/events/processCollectedSignatures/index.js
@@ -68,7 +68,7 @@ function processCollectedSignaturesBuilder(config) {
         if (v.length !== NumberOfCollectedSignatures) {
           throw new Error('Number of recovered signatures is not equal collected signatures')
         }
-        
+
         let gasEstimate
         try {
           logger.debug('Estimate gas')

--- a/oracle/src/events/processCollectedSignatures/index.js
+++ b/oracle/src/events/processCollectedSignatures/index.js
@@ -46,7 +46,7 @@ function processCollectedSignaturesBuilder(config) {
         logger.info(`Processing CollectedSignatures ${colSignature.transactionHash}`)
         const message = await homeBridge.methods.message(messageHash).call()
 
-        logger.debug(`Number of signatures to get ${NumberOfCollectedSignatures}`)
+        logger.debug({ NumberOfCollectedSignatures }, 'Number of signatures to get')
 
         const requiredSignatures = []
         requiredSignatures.length = NumberOfCollectedSignatures
@@ -64,10 +64,6 @@ function processCollectedSignaturesBuilder(config) {
         })
 
         await Promise.all(signaturePromises)
-
-        if (v.length !== NumberOfCollectedSignatures) {
-          throw new Error('Number of recovered signatures is not equal collected signatures')
-        }
 
         let gasEstimate
         try {

--- a/oracle/src/events/processCollectedSignatures/index.js
+++ b/oracle/src/events/processCollectedSignatures/index.js
@@ -46,7 +46,11 @@ function processCollectedSignaturesBuilder(config) {
         logger.info(`Processing CollectedSignatures ${colSignature.transactionHash}`)
         const message = await homeBridge.methods.message(messageHash).call()
 
-        const requiredSignatures = new Array(NumberOfCollectedSignatures).fill(0)
+        logger.debug(`Number of signatures to get ${NumberOfCollectedSignatures}`)
+
+        const requiredSignatures = []
+        requiredSignatures.length = NumberOfCollectedSignatures
+        requiredSignatures.fill(0)
 
         const [v, r, s] = [[], [], []]
         logger.debug('Getting message signatures')
@@ -61,6 +65,10 @@ function processCollectedSignaturesBuilder(config) {
 
         await Promise.all(signaturePromises)
 
+        if (v.length !== NumberOfCollectedSignatures) {
+          throw new Error('Number of recovered signatures is not equal collected signatures')
+        }
+        
         let gasEstimate
         try {
           logger.debug('Estimate gas')


### PR DESCRIPTION
Closes #239 

The previous way to initialize the array to iterate getting signatures in the case of the `CollectedSignatures` event was changed as part of addressing the comment https://github.com/poanetwork/tokenbridge/pull/199#discussion_r322159608. 

This code leads to initializing the array with one element that is why only one signature is received from the contract.