### PR TITLE
Add RabbitMQ and Redis networks to new workers on docker-compose-erc-native file

### DIFF
--- a/oracle/docker-compose-erc-native.yml
+++ b/oracle/docker-compose-erc-native.yml
@@ -7,12 +7,15 @@ services:
       service: rabbit
     networks:
       - net_rabbit_bridge_transfer
+      - net_rabbit_bridge_half_duplex_transfer
+      - net_rabbit_bridge_swap_tokens_worker
   redis:
     extends:
       file: docker-compose.yml
       service: redis
     networks:
       - net_db_bridge_transfer
+      - net_db_bridge_half_duplex_transfer
   bridge_request:
     extends:
       file: docker-compose.yml


### PR DESCRIPTION
Fixes a bug that produced the watcher `bridge_half_duplex_transfer` and worker `bridge_swap_tokens_worker` to not be able to connect to RabbitMQ and Redis when deploying the component using ansible playbooks