### PR TITLE
Fix home gas price fallback value usage in monitor

### DIFF
--- a/monitor/validators.js
+++ b/monitor/validators.js
@@ -87,9 +87,10 @@ async function main(bridgeMode) {
   const homeVBalances = {}
 
   logger.debug('calling home getGasPrices')
-  const homeGasPrice =
-    (await gasPriceFromSupplier(() => fetch(COMMON_HOME_GAS_PRICE_SUPPLIER_URL), homeGasPriceSupplierOpts)) ||
-    Web3Utils.toBN(COMMON_HOME_GAS_PRICE_FALLBACK)
+  const fallbackGasPrice = Web3Utils.toBN(COMMON_HOME_GAS_PRICE_FALLBACK)
+  const homeGasPrice = fallbackGasPrice.isZero()
+    ? fallbackGasPrice
+    : await gasPriceFromSupplier(() => fetch(COMMON_HOME_GAS_PRICE_SUPPLIER_URL), homeGasPriceSupplierOpts)
   const homeGasPriceGwei = Web3Utils.fromWei(homeGasPrice.toString(), 'gwei')
   const homeTxCost = homeGasPrice.mul(Web3Utils.toBN(MONITOR_VALIDATOR_HOME_TX_LIMIT))
 


### PR DESCRIPTION
Closes #237

If `COMMON_HOME_GAS_PRICE_FALLBACK` is set to `0` the `leftTx` attribute will be set to a very big number as specified in this change https://github.com/poanetwork/tokenbridge/pull/142#discussion_r302644176 , so then `results.homeOk` will be true when validators have `0` balance as in xDai Chain.

Most of the logic was in place, this PR only fixes the precedence order of the gas price parameters used in the calculation 