### PR TITLE
Fix warning in logging configuration in deployment

### DIFF
--- a/deployment/roles/oracle/tasks/logging.yml
+++ b/deployment/roles/oracle/tasks/logging.yml
@@ -4,6 +4,8 @@
     - docker-compose
     - docker-compose-transfer
     - docker-compose-erc-native
+  loop_control:
+    loop_var: file
 
 - name: Set the local container logs configuration file
   template:

--- a/deployment/roles/oracle/tasks/logging_by_syslog.yml
+++ b/deployment/roles/oracle/tasks/logging_by_syslog.yml
@@ -1,7 +1,7 @@
 ---
 - name: Slurp docker compose file
   slurp:
-    src: "{{ bridge_path }}/oracle/{{ item }}.yml"
+    src: "{{ bridge_path }}/oracle/{{ file }}.yml"
   register: docker_compose_slurp
 
 - name: Parse docker compose file
@@ -16,4 +16,4 @@
 - name: Write updated docker file
   copy:
     content: "{{ docker_compose_parsed | to_yaml }}"
-    dest: "{{ bridge_path }}/oracle/{{ item }}.yml"
+    dest: "{{ bridge_path }}/oracle/{{ file }}.yml"


### PR DESCRIPTION
Closes #270 

Add a specific var name to avoid the conflict with the default variable name `item` used in the imported task.

The warning is now gone, I also tested that the logs for all the oracle services are received in a remote logging server.