### PR TITLE
Add custom response for favicon resource in monitor

### DIFF
--- a/monitor/index.js
+++ b/monitor/index.js
@@ -5,6 +5,7 @@ const { readFile } = require('./utils/file')
 const app = express()
 const bridgeRouter = express.Router({ mergeParams: true })
 
+app.get('/favicon.ico', (req, res) => res.sendStatus(204))
 app.use('/:bridgeName', bridgeRouter)
 
 bridgeRouter.get('/', async (req, res, next) => {


### PR DESCRIPTION
Closes #271 

By default web browsers send a request to `favicon.ico`, this PR handles that request responding with the status code `204 No Content`.