### PR TITLE
Use oracle docker hub image for oracle deployment

### DIFF
--- a/deployment-e2e/molecule/tests/test_all.py
+++ b/deployment-e2e/molecule/tests/test_all.py
@@ -9,7 +9,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_repo(host):
     assert host.file('/home/poadocker/bridge').exists
     assert host.file('/home/poadocker/bridge').is_directory
-    assert host.file('/home/poadocker/bridge/package.json').exists
 
 
 def test_docker_group(host):

--- a/deployment-e2e/molecule/ultimate-commons/oracle-add-docker-external-network.yml
+++ b/deployment-e2e/molecule/ultimate-commons/oracle-add-docker-external-network.yml
@@ -1,7 +1,7 @@
 ---
 - name: Slurp docker compose file
   slurp:
-    src: "/home/poadocker/bridge/oracle/{{ item }}.yml"
+    src: "/home/poadocker/bridge/oracle/{{ file }}.yml"
   register: docker_compose_slurp
 - name: Parse docker compose file
   set_fact:
@@ -23,4 +23,4 @@
 - name: Write updated docker file
   copy:
     content: "{{ docker_compose_parsed | to_yaml }}"
-    dest: "/home/poadocker/bridge/oracle/{{ item }}.yml"
+    dest: "/home/poadocker/bridge/oracle/{{ file }}.yml"

--- a/deployment-e2e/molecule/ultimate-commons/oracle-docker-compose.yml
+++ b/deployment-e2e/molecule/ultimate-commons/oracle-docker-compose.yml
@@ -7,7 +7,7 @@
     shell: service poabridge stop
 
   - name: Build current oracle image
-    shell: docker build -t oracle:ultimate-testing --file oracle/Dockerfile .
+    shell: docker build -t oracle:ultimate-testing --file oracle/Dockerfile --build-arg DOT_ENV_PATH=e2e-commons/components-envs/oracle.env .
     delegate_to: 127.0.0.1
     become: false
     args:

--- a/deployment-e2e/molecule/ultimate-commons/oracle-docker-compose.yml
+++ b/deployment-e2e/molecule/ultimate-commons/oracle-docker-compose.yml
@@ -11,6 +11,8 @@
       - docker-compose
       - docker-compose-transfer
       - docker-compose-erc-native
+    loop_control:
+      loop_var: file
 
   - name: start the service
     shell: service poabridge start

--- a/deployment-e2e/molecule/ultimate-commons/oracle-docker-compose.yml
+++ b/deployment-e2e/molecule/ultimate-commons/oracle-docker-compose.yml
@@ -7,7 +7,7 @@
     shell: service poabridge stop
 
   - name: Build current oracle image
-    shell: docker build -t oracle:ultimate-testing --file oracle/Dockerfile --build-arg DOT_ENV_PATH=e2e-commons/components-envs/oracle.env .
+    shell: docker build -t oracle:ultimate-testing --file oracle/Dockerfile .
     delegate_to: 127.0.0.1
     become: false
     args:

--- a/deployment-e2e/molecule/ultimate-commons/oracle-docker-compose.yml
+++ b/deployment-e2e/molecule/ultimate-commons/oracle-docker-compose.yml
@@ -6,6 +6,23 @@
   - name: stop the service
     shell: service poabridge stop
 
+  - name: Build current oracle image
+    shell: docker build -t oracle:ultimate-testing --file oracle/Dockerfile .
+    delegate_to: 127.0.0.1
+    become: false
+    args:
+      chdir: "{{ lookup('env', 'PWD') }}/.."
+
+  - name: Replace oracle image
+    replace:
+      path: "/home/poadocker/bridge/oracle/{{ item }}.yml"
+      regexp: 'poanetwork/tokenbridge-oracle:latest'
+      replace: "oracle:ultimate-testing"
+    with_items:
+      - docker-compose
+      - docker-compose-transfer
+      - docker-compose-erc-native
+
   - include_tasks: oracle-add-docker-external-network.yml
     with_items:
       - docker-compose

--- a/deployment/roles/common/tasks/main.yml
+++ b/deployment/roles/common/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Include repo tasks
   include_tasks: repo.yml
-  when: skip_task != true
+  when: skip_task != true and skip_repo is undefined
 
 - name: Include logging tasks
   include_tasks: logging.yml

--- a/deployment/roles/oracle/meta/main.yml
+++ b/deployment/roles/oracle/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - role: common
+  - { role: common, skip_repo: true }

--- a/deployment/roles/oracle/tasks/jumpbox.yml
+++ b/deployment/roles/oracle/tasks/jumpbox.yml
@@ -1,5 +1,5 @@
 ---
-- name: Build the containers
-  shell: docker-compose build
+- name: Pull the containers images
+  shell: docker-compose pull
   args:
     chdir: "{{ bridge_path }}/oracle"

--- a/deployment/roles/oracle/tasks/post_config.yml
+++ b/deployment/roles/oracle/tasks/post_config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get blocks
   become_user: "{{ compose_service_user }}"
-  shell: docker-compose run --entrypoint "node scripts/getValidatorStartBlocks.js" bridge_affirmation
+  shell: docker-compose run --rm --entrypoint "node scripts/getValidatorStartBlocks.js" bridge_affirmation
   args:
     chdir: "{{ bridge_path }}/oracle"
   register: BLOCKS
@@ -18,7 +18,7 @@
 
 - name: Get validator address
   become_user: "{{ compose_service_user }}"
-  shell: docker-compose run -e ORACLE_VALIDATOR_ADDRESS_PRIVATE_KEY="{{ ORACLE_VALIDATOR_ADDRESS_PRIVATE_KEY }}" --entrypoint "node scripts/privateKeyToAddress.js" bridge_affirmation
+  shell: docker-compose run --rm -e ORACLE_VALIDATOR_ADDRESS_PRIVATE_KEY="{{ ORACLE_VALIDATOR_ADDRESS_PRIVATE_KEY }}" --entrypoint "node scripts/privateKeyToAddress.js" bridge_affirmation
   args:
     chdir: "{{ bridge_path }}/oracle"
   register: VADDRESS
@@ -29,7 +29,7 @@
 
 - name: Get foreign erc type
   become_user: "{{ compose_service_user }}"
-  shell: docker-compose run --entrypoint "node scripts/initialChecks.js" bridge_affirmation
+  shell: docker-compose run --rm --entrypoint "node scripts/initialChecks.js" bridge_affirmation
   args:
     chdir: "{{ bridge_path }}/oracle"
   register: ERCTYPE

--- a/deployment/roles/oracle/tasks/pre_config.yml
+++ b/deployment/roles/oracle/tasks/pre_config.yml
@@ -3,6 +3,7 @@
   file:
     path: "{{ bridge_path }}/oracle"
     state: directory
+    mode: '0755'
 
 - name: Install .env config
   template:
@@ -13,6 +14,7 @@
   copy:
     src: ../../../../oracle/{{ item }}
     dest: "{{ bridge_path }}/oracle/"
+    mode: '0755'
   with_items:
     - docker-compose.yml
     - docker-compose-transfer.yml

--- a/deployment/roles/oracle/tasks/pre_config.yml
+++ b/deployment/roles/oracle/tasks/pre_config.yml
@@ -1,5 +1,19 @@
 ---
+- name: Create oracle directory
+  file:
+    path: "{{ bridge_path }}/oracle"
+    state: directory
+
 - name: Install .env config
   template:
     src: .env.j2
     dest: "{{ bridge_path }}/oracle/.env"
+
+- name: Copy docker-compose files
+  copy:
+    src: ../../../../oracle/{{ item }}
+    dest: "{{ bridge_path }}/oracle/"
+  with_items:
+    - docker-compose.yml
+    - docker-compose-transfer.yml
+    - docker-compose-erc-native.yml

--- a/deployment/roles/oracle/tasks/servinstall.yml
+++ b/deployment/roles/oracle/tasks/servinstall.yml
@@ -1,6 +1,5 @@
 # This role creates a poabridge service which is designed to manage docker-compose bridge deployment.
 # /etc/init.d/poabridge start, status, stop, restart - does what the services usually do in such cases.
-# /etc/init.d/poabridge rebuild - builds a new bridge deployment from scratch.
 ---
 - name: "Set poabridge service"
   template:

--- a/deployment/roles/oracle/templates/poabridge.j2
+++ b/deployment/roles/oracle/templates/poabridge.j2
@@ -52,14 +52,6 @@ status(){
     sudo -u "{{ compose_service_user }}" /usr/local/bin/docker-compose $composefileoverride  ps
 }
 
-rebuild(){
-    echo "Rebuild bridge.."
-    cd $WORKDIR
-    sudo -u "{{ compose_service_user }}" /usr/local/bin/docker-compose $composefileoverride down -v
-    sudo -u "{{ compose_service_user }}" /usr/local/bin/docker-compose $composefileoverride rm -fv
-    sudo -u "{{ compose_service_user }}" ORACLE_VALIDATOR_ADDRESS=$vaddr ORACLE_VALIDATOR_ADDRESS_PRIVATE_KEY=$vkey /usr/local/bin/docker-compose $composefileoverride up --detach --force-recreate --no-deps --build
-}
-
 
 case "$1" in
 
@@ -81,12 +73,8 @@ case "$1" in
     start
     ;;
 
-  rebuild)
-    rebuild
-    ;;
-
   *)
-    echo $"Usage: $0 {start|stop|restart|rebuild|status}"
+    echo $"Usage: $0 {start|stop|restart|status}"
     exit 1
     ;;
 

--- a/e2e-commons/docker-compose.yml
+++ b/e2e-commons/docker-compose.yml
@@ -30,8 +30,7 @@ services:
     build:
       context: ..
       dockerfile: oracle/Dockerfile
-      args:
-        DOT_ENV_PATH: e2e-commons/components-envs/oracle.env
+    env_file: ../e2e-commons/components-envs/oracle.env
     environment:
     - NODE_ENV=production
     command: "true"
@@ -41,8 +40,7 @@ services:
     build:
       context: ..
       dockerfile: oracle/Dockerfile
-      args:
-        DOT_ENV_PATH: e2e-commons/components-envs/oracle-erc20.env
+    env_file: ../e2e-commons/components-envs/oracle-erc20.env
     environment:
     - NODE_ENV=production
     command: "true"
@@ -52,8 +50,7 @@ services:
     build:
       context: ..
       dockerfile: oracle/Dockerfile
-      args:
-        DOT_ENV_PATH: e2e-commons/components-envs/oracle-erc20-native.env
+    env_file: ../e2e-commons/components-envs/oracle-erc20-native.env
     environment:
     - NODE_ENV=production
     command: "true"
@@ -63,8 +60,7 @@ services:
     build:
       context: ..
       dockerfile: oracle/Dockerfile
-      args:
-        DOT_ENV_PATH: e2e-commons/components-envs/oracle-amb.env
+    env_file: ../e2e-commons/components-envs/oracle-amb.env
     environment:
     - NODE_ENV=production
     command: "true"

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -22,8 +22,6 @@ RUN mv ./contracts/build ./ && rm -rf ./contracts/* ./contracts/.[!.]* && mv ./b
 COPY ./commons ./commons
 
 COPY ./oracle ./oracle
-ARG DOT_ENV_PATH=./oracle/.env
-COPY ${DOT_ENV_PATH} ./oracle/.env
 
 WORKDIR /mono/oracle
 CMD echo "To start a bridge process run:" \

--- a/oracle/docker-compose-erc-native.yml
+++ b/oracle/docker-compose-erc-native.yml
@@ -40,9 +40,7 @@ services:
   bridge_transfer:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment:
       - NODE_ENV=production
@@ -55,9 +53,7 @@ services:
   bridge_half_duplex_transfer:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment:
       - NODE_ENV=production
@@ -70,9 +66,7 @@ services:
   bridge_swap_tokens_worker:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment:
       - NODE_ENV=production

--- a/oracle/docker-compose-transfer.yml
+++ b/oracle/docker-compose-transfer.yml
@@ -37,9 +37,7 @@ services:
   bridge_transfer:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment:
       - NODE_ENV=production

--- a/oracle/docker-compose.yml
+++ b/oracle/docker-compose.yml
@@ -32,9 +32,7 @@ services:
   bridge_request:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment: 
       - NODE_ENV=production 
@@ -47,9 +45,7 @@ services:
   bridge_collected:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment: 
       - NODE_ENV=production 
@@ -62,9 +58,7 @@ services:
   bridge_affirmation:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment: 
       - NODE_ENV=production 
@@ -77,9 +71,7 @@ services:
   bridge_senderhome:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment: 
       - NODE_ENV=production 
@@ -92,9 +84,7 @@ services:
   bridge_senderforeign:
     cpus: 0.1
     mem_limit: 500m
-    build:
-      context: ..
-      dockerfile: oracle/Dockerfile
+    image: poanetwork/tokenbridge-oracle:latest
     env_file: ./.env
     environment: 
       - NODE_ENV=production 


### PR DESCRIPTION
Closes #268 

As part of the oracle deployment now the repo is not copied to the host, only the necessary `docker-compose*` files and the docker image is pulled instead of built in the host.

In the ultimate e2e tests, a local image is built from the current implementation of the oracle and it is used instead of the one published in docker hub