### PR TITLE
Upgrade pip version in deployment common tasks

### DIFF
--- a/deployment/roles/common/tasks/dependencies.yml
+++ b/deployment/roles/common/tasks/dependencies.yml
@@ -32,6 +32,9 @@
     group: "root"
     mode: "0755"
 
+- name: Upgrade pip version
+  shell: pip3 install --upgrade pip
+
 - name: Install python docker library
   shell: pip3 install docker docker-compose setuptools
 


### PR DESCRIPTION
This PR fixes the issue with python imports when using docker-compose in the ansible deployment scripts. (Example: https://app.circleci.com/jobs/github/poanetwork/tokenbridge/13996).

When pip is installed it seems to be using an older version (`8.1.1`). Upgrading to the latest version (`20.0.2`) fixed the issue