### PR TITLE
Update monitor half duplex transfer filter

### DIFF
--- a/monitor/utils/events.js
+++ b/monitor/utils/events.js
@@ -146,11 +146,7 @@ async function main(mode) {
           })).map(normalizeEvent)
 
           // Remove events after the ES
-          const validHalfDuplexTransfers = await filterTransferBeforeES(
-            halfDuplexTransferEvents,
-            web3Foreign,
-            foreignBridge
-          )
+          const validHalfDuplexTransfers = await filterTransferBeforeES(halfDuplexTransferEvents)
 
           transferEvents = [...validHalfDuplexTransfers, ...transferEvents]
         })

--- a/monitor/utils/tokenUtils.js
+++ b/monitor/utils/tokenUtils.js
@@ -1,32 +1,18 @@
-let beforeESBiggestBlockNumber = 0
+// https://etherscan.io/tx/0xd0c3c92c94e05bc71256055ce8c4c993e047f04e04f3283a04e4cb077b71f6c6
+const blockNumberHalfDuplexDisabled = 9884448
 
 /**
- *
- * Returns true if the event was before the Emergency Shutdown.
- * The method has an optimization to avoid making request if a bigger block number is confirmed
- * to be before the ES. Events should be iterated from newer to older order to use the optimization.
+ * Returns true if the event was before the bridge stopped supporting half duplex transfers.
  */
-async function transferBeforeES(event, web3Foreign, foreignBridge) {
-  const { blockNumber } = event
-
-  if (blockNumber < beforeESBiggestBlockNumber) {
-    return true
-  }
-
-  const block = await web3Foreign.eth.getBlock(blockNumber)
-
-  const tokenSwapAllowed = await foreignBridge.methods.isTokenSwapAllowed(block.timestamp).call()
-  if (tokenSwapAllowed) {
-    beforeESBiggestBlockNumber = blockNumber
-  }
-  return tokenSwapAllowed
+async function transferBeforeES(event) {
+  return event.blockNumber < blockNumberHalfDuplexDisabled
 }
 
-async function filterTransferBeforeES(array, web3Foreign, foreignBridge) {
+async function filterTransferBeforeES(array) {
   const newArray = []
   // Iterate events from newer to older
   for (let i = array.length - 1; i >= 0; i--) {
-    const beforeES = await transferBeforeES(array[i], web3Foreign, foreignBridge)
+    const beforeES = await transferBeforeES(array[i])
     if (beforeES) {
       // add element to first position so the new array will have the same order
       newArray.unshift(array[i])


### PR DESCRIPTION
Closes #308 

Now that `isTokenSwapAllowed` can't be used to detect if an event was processed by the bridge (before the ES), I updated the code to use the block number in which the foreign bridge was upgraded and stopped supporting transfers from the half duplex token.