### PR TITLE
Fix monitor balances displayed for erc to native

### DIFF
--- a/monitor/getBalances.js
+++ b/monitor/getBalances.js
@@ -3,6 +3,7 @@ const BN = require('bignumber.js')
 const Web3 = require('web3')
 const logger = require('./logger')('getBalances')
 const { BRIDGE_MODES } = require('../commons')
+const { blockNumberHalfDuplexDisabled } = require('./utils/tokenUtils')
 
 const Web3Utils = Web3.utils
 
@@ -94,7 +95,9 @@ async function main(bridgeMode) {
       if (halfDuplexTokenAddress !== erc20Address) {
         const halfDuplexToken = new web3Foreign.eth.Contract(ERC20_ABI, halfDuplexTokenAddress)
         logger.debug('calling halfDuplexToken.methods.balanceOf')
-        foreignHalfDuplexErc20Balance = await halfDuplexToken.methods.balanceOf(COMMON_FOREIGN_BRIDGE_ADDRESS).call()
+        foreignHalfDuplexErc20Balance = await halfDuplexToken.methods
+          .balanceOf(COMMON_FOREIGN_BRIDGE_ADDRESS)
+          .call(null, blockNumberHalfDuplexDisabled)
         logger.debug('getting last block numbers')
         const block = await web3Foreign.eth.getBlock('latest')
 
@@ -139,8 +142,7 @@ async function main(bridgeMode) {
     const foreignErc20BalanceBN = new BN(foreignErc20Balance)
     const investedAmountInDaiBN = new BN(investedAmountInDai)
     const bridgeDsrBalanceBN = new BN(bridgeDsrBalance)
-    const halfDuplexErc20BalanceBN =
-      displayHalfDuplexToken && tokenSwapAllowed ? new BN(foreignHalfDuplexErc20Balance) : new BN(0)
+    const halfDuplexErc20BalanceBN = displayHalfDuplexToken ? new BN(foreignHalfDuplexErc20Balance) : new BN(0)
 
     const diff = foreignErc20BalanceBN
       .plus(halfDuplexErc20BalanceBN)

--- a/monitor/utils/tokenUtils.js
+++ b/monitor/utils/tokenUtils.js
@@ -22,5 +22,6 @@ async function filterTransferBeforeES(array) {
 }
 
 module.exports = {
-  filterTransferBeforeES
+  filterTransferBeforeES,
+  blockNumberHalfDuplexDisabled
 }


### PR DESCRIPTION
Related to https://github.com/poanetwork/tokenbridge/issues/308

The balance of half duplex erc20 token is now retrieved at the block when the xdai bridge stopped supporting SAI.

Here is the output of the balances for xdai bridge:

```json
{
    "home": {
        "totalSupply": "60421.760557667686859071",
        "deposits": 1894,
        "withdrawals": 2403
    },
    "foreign": {
        "erc20Balance": "195.626112968225706409",
        "halfDuplexErc20BalanceAfterES": "49.938645266079271041",
        "investedErc20Balance": "60180.084059345757051077",
        "accumulatedInterest": "0.000009999998798933",
        "deposits": 1894,
        "withdrawals": 2412
    },
    "balanceDiff": 3.8882599123751693,
    "lastChecked": 1587129571,
    "depositsDiff": 0,
    "withdrawalDiff": -9
}
```