### PR TITLE
Return back filter for tx with TokensSwapped

### DIFF
--- a/monitor/utils/events.js
+++ b/monitor/utils/events.js
@@ -114,7 +114,7 @@ async function main(mode) {
     let directTransfers = transferEvents
     const tokensSwappedAbiExists = FOREIGN_ABI.filter(e => e.type === 'event' && e.name === 'TokensSwapped')[0]
     if (tokensSwappedAbiExists) {
-      logger.debug("collecting half duplex tokens participated in the bridge balance")
+      logger.debug('collecting half duplex tokens participated in the bridge balance')
       logger.debug("calling foreignBridge.getPastEvents('TokensSwapped')")
       const tokensSwappedEvents = await getPastEvents(foreignBridge, {
         event: 'TokensSwapped',
@@ -150,7 +150,7 @@ async function main(mode) {
         uniqueTokenAddresses.map(async tokenAddress => {
           const halfDuplexTokenContract = new web3Foreign.eth.Contract(ERC20_ABI, tokenAddress)
 
-          logger.debug("Half duplex token:", tokenAddress)
+          logger.debug('Half duplex token:', tokenAddress)
           logger.debug("calling halfDuplexTokenContract.getPastEvents('Transfer')")
           const halfDuplexTransferEvents = (await getPastEvents(halfDuplexTokenContract, {
             event: 'Transfer',
@@ -162,7 +162,7 @@ async function main(mode) {
           })).map(normalizeEvent)
 
           // Remove events after the ES
-          logger.debug("filtering half duplex transfers happened before ES")
+          logger.debug('filtering half duplex transfers happened before ES')
           const validHalfDuplexTransfers = await filterTransferBeforeES(halfDuplexTransferEvents)
 
           transferEvents = [...validHalfDuplexTransfers, ...transferEvents]

--- a/monitor/utils/tokenUtils.js
+++ b/monitor/utils/tokenUtils.js
@@ -1,0 +1,27 @@
+// https://etherscan.io/tx/0xd0c3c92c94e05bc71256055ce8c4c993e047f04e04f3283a04e4cb077b71f6c6
+const blockNumberHalfDuplexDisabled = 9884448
+
+/**
+ * Returns true if the event was before the bridge stopped supporting half duplex transfers.
+ */
+async function transferBeforeES(event) {
+  return event.blockNumber < blockNumberHalfDuplexDisabled
+}
+
+async function filterTransferBeforeES(array) {
+  const newArray = []
+  // Iterate events from newer to older
+  for (let i = array.length - 1; i >= 0; i--) {
+    const beforeES = await transferBeforeES(array[i])
+    if (beforeES) {
+      // add element to first position so the new array will have the same order
+      newArray.unshift(array[i])
+    }
+  }
+  return newArray
+}
+
+module.exports = {
+  filterTransferBeforeES,
+  blockNumberHalfDuplexDisabled
+}


### PR DESCRIPTION
Fixes the changes introduced in #331 

From now on, it is also recommended to use monitor start blocks, from which SAI transfers were no longer accepted.
For xDai bridge, the following settings can be applied:
```
MONITOR_HOME_START_BLOCK=9393197
MONITOR_FOREIGN_START_BLOCK=9867407
```