### PR TITLE
Update the contract's submodule to the release 5.0.0

### DIFF
--- a/parity/chain-foreign.json
+++ b/parity/chain-foreign.json
@@ -19,6 +19,7 @@
     "maxCodeSize": 24576,
     "maxCodeSizeTransition": "0x0",
     "eip140Transition": "0x0",
+    "eip145Transition": "0x0",
     "eip211Transition": "0x0",
     "eip214Transition": "0x0",
     "eip658Transition": "0x0",

--- a/parity/chain.json
+++ b/parity/chain.json
@@ -19,6 +19,7 @@
 		"maxCodeSize": 24576,
 		"maxCodeSizeTransition": "0x0",
 		"eip140Transition": "0x0",
+		"eip145Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",
 		"eip658Transition": "0x0",


### PR DESCRIPTION
Besides updating the reference to the new version of contracts ([`5.0.0`](https://github.com/poanetwork/tokenbridge-contracts/releases/tag/5.0.0)) this PR will check through e2e tests that new revision does not break any existing functionality.