### PR TITLE
Oracle services dependency in docker-compose file

### DIFF
--- a/oracle/docker-compose-erc-native.yml
+++ b/oracle/docker-compose-erc-native.yml
@@ -42,6 +42,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment:
       - NODE_ENV=production
@@ -55,6 +58,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment:
       - NODE_ENV=production
@@ -68,6 +74,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment:
       - NODE_ENV=production
@@ -80,6 +89,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment:
       - NODE_ENV=production

--- a/oracle/docker-compose-transfer.yml
+++ b/oracle/docker-compose-transfer.yml
@@ -38,6 +38,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment:
       - NODE_ENV=production

--- a/oracle/docker-compose.yml
+++ b/oracle/docker-compose.yml
@@ -33,6 +33,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment: 
       - NODE_ENV=production 
@@ -46,6 +49,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment: 
       - NODE_ENV=production 
@@ -59,6 +65,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment: 
       - NODE_ENV=production 
@@ -72,6 +81,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment: 
       - NODE_ENV=production 
@@ -85,6 +97,9 @@ services:
     cpus: 0.1
     mem_limit: 500m
     image: poanetwork/tokenbridge-oracle:latest
+    depends_on:
+      - redis
+      - rabbit
     env_file: ./.env
     environment: 
       - NODE_ENV=production 


### PR DESCRIPTION
The dependency between the oracle services added in order to start the the oracle workers after RedisDB and RabbitMQ