### PR TITLE
Update UI transfer loading to wait block confirmations from contracts

### DIFF
--- a/ui/src/components/Loading.js
+++ b/ui/src/components/Loading.js
@@ -9,9 +9,9 @@ export class Loading extends React.Component {
   render() {
     const { REACT_APP_UI_STYLES } = process.env
     const { alertStore } = this.props.RootStore
-    const { loadingStepIndex, loadingSteps, blockConfirmations } = alertStore
+    const { loadingStepIndex, loadingSteps, blockConfirmations, requiredBlockConfirmations } = alertStore
     const style = alertStore.showLoading ? { display: 'flex' } : { display: 'none' }
-    const progress = loadingStepIndex === 3 ? 100 : loadingStepIndex * 25 + blockConfirmations * 4
+    const progress = loadingStepIndex === 3 ? 100 : 25 + (blockConfirmations / requiredBlockConfirmations) * 50
     const radius = REACT_APP_UI_STYLES === 'stake' ? 33 : 40
 
     return (
@@ -25,6 +25,7 @@ export class Loading extends React.Component {
           {loadingStepIndex > 0 && (
             <ProgressRing
               confirmationNumber={blockConfirmations}
+              requiredBlockConfirmations={requiredBlockConfirmations}
               hideConfirmationNumber={loadingStepIndex > 1}
               progress={progress}
               radius={radius}

--- a/ui/src/components/ProgressRing.js
+++ b/ui/src/components/ProgressRing.js
@@ -7,17 +7,40 @@ export class ProgressRing extends Component {
   }
 
   render() {
-    const { radius, stroke, progress, confirmationNumber, hideConfirmationNumber } = this.props
+    const {
+      radius,
+      stroke,
+      progress,
+      confirmationNumber,
+      requiredBlockConfirmations,
+      hideConfirmationNumber
+    } = this.props
     const { REACT_APP_UI_STYLES } = process.env
     const { circumference, normalizedRadius } = this.state
     const strokeDashoffset = circumference - (progress / 100) * circumference
-    const confirmations = hideConfirmationNumber ? '' : `${confirmationNumber}/8`
+    const confirmations = hideConfirmationNumber ? '' : `${confirmationNumber}/${requiredBlockConfirmations}`
     const strokeColor = REACT_APP_UI_STYLES === 'stake' ? '#E6ECF1' : '#7b5ab2'
     const strokeProgressColor = REACT_APP_UI_STYLES === 'stake' ? '#4DA9A6' : '#60dc97'
-    const textParams =
-      REACT_APP_UI_STYLES === 'stake'
-        ? { x: '22', y: '38', font: 'Roboto', fontSize: '14', fill: '#242A31' }
-        : { x: '28', y: '47', font: 'Nunito', fontSize: '18', fill: 'white' }
+
+    let textParams
+    if (REACT_APP_UI_STYLES === 'stake') {
+      const xPosTextParam =
+        requiredBlockConfirmations >= 10 && confirmationNumber >= 10
+          ? '15'
+          : requiredBlockConfirmations >= 10
+            ? '20'
+            : '22'
+      textParams = { x: xPosTextParam, y: '38', font: 'Roboto', fontSize: '14', fill: '#242A31' }
+    } else {
+      const xPosTextParam =
+        requiredBlockConfirmations >= 10 && confirmationNumber >= 10
+          ? '16'
+          : requiredBlockConfirmations >= 10
+            ? '22'
+            : '28'
+      textParams = { x: xPosTextParam, y: '47', font: 'Nunito', fontSize: '18', fill: 'white' }
+    }
+
     const progressTransform = REACT_APP_UI_STYLES === 'stake' ? 'rotate(-90 33 33)' : ''
 
     return (

--- a/ui/src/stores/AlertStore.js
+++ b/ui/src/stores/AlertStore.js
@@ -14,6 +14,9 @@ class AlertStore {
   blockConfirmations = 0
 
   @observable
+  requiredBlockConfirmations = 8
+
+  @observable
   showDailyQuotaInfo = false
 
   homeConnectionErrorSended = false
@@ -95,6 +98,11 @@ class AlertStore {
   @action
   setBlockConfirmations(blocks) {
     this.blockConfirmations = blocks
+  }
+
+  @action
+  setRequiredBlockConfirmations(blocks) {
+    this.requiredBlockConfirmations = blocks
   }
 
   @action

--- a/ui/src/stores/TxStore.js
+++ b/ui/src/stores/TxStore.js
@@ -25,6 +25,10 @@ class TxStore {
         return
       }
       try {
+        const requiredConfirmations =
+          this.web3Store.metamaskNet.id === this.web3Store.homeNet.id
+            ? this.homeStore.requiredBlockConfirmations
+            : this.foreignStore.requiredBlockConfirmations
         const gasPrice = this.gasPriceStore.gasPriceInHex
         const gas = await estimateGas(this.web3Store.injectedWeb3, to, gasPrice, from, value, data)
         return this.web3Store.injectedWeb3.eth
@@ -40,6 +44,7 @@ class TxStore {
           .on('transactionHash', hash => {
             console.log('txHash', hash)
             this.txsValues[hash] = sentValue
+            this.alertStore.setRequiredBlockConfirmations(requiredConfirmations)
             this.alertStore.setLoadingStepIndex(1)
             addPendingTransaction()
             this.getTxReceipt(hash)
@@ -120,8 +125,8 @@ class TxStore {
         if (this.isStatusSuccess(res)) {
           if (this.web3Store.metamaskNet.id === this.web3Store.homeNet.id) {
             const blockConfirmations = this.homeStore.latestBlockNumber - res.blockNumber
-            if (blockConfirmations >= 8) {
-              this.alertStore.setBlockConfirmations(8)
+            if (blockConfirmations >= this.homeStore.requiredBlockConfirmations) {
+              this.alertStore.setBlockConfirmations(this.homeStore.requiredBlockConfirmations)
               this.alertStore.setLoadingStepIndex(2)
 
               if (yn(process.env.REACT_APP_UI_FOREIGN_WITHOUT_EVENTS)) {
@@ -147,8 +152,8 @@ class TxStore {
             }
           } else {
             const blockConfirmations = this.foreignStore.latestBlockNumber - res.blockNumber
-            if (blockConfirmations >= 8) {
-              this.alertStore.setBlockConfirmations(8)
+            if (blockConfirmations >= this.foreignStore.requiredBlockConfirmations) {
+              this.alertStore.setBlockConfirmations(this.foreignStore.requiredBlockConfirmations)
               this.alertStore.setLoadingStepIndex(2)
 
               if (yn(process.env.REACT_APP_UI_HOME_WITHOUT_EVENTS)) {

--- a/ui/src/stores/__tests__/HomeStore.test.js
+++ b/ui/src/stores/__tests__/HomeStore.test.js
@@ -34,6 +34,7 @@ describe('HomeStore', () => {
     contract.getRequiredSignatures = jest.fn(() => Promise.resolve(1))
     contract.getValidatorCount = jest.fn(() => Promise.resolve(1))
     contract.getValidatorList = jest.fn(() => Promise.resolve(['0x52576e0cCaA0C9157142Fbf1d1c6DbfAc5e4E33e']))
+    contract.getRequiredBlockConfirmations = jest.fn(() => Promise.resolve(1))
 
     // When
     new HomeStore(rootStore)

--- a/ui/src/stores/utils/contract.js
+++ b/ui/src/stores/utils/contract.js
@@ -102,3 +102,10 @@ export const getValidatorContract = contract => contract.methods.validatorContra
 export const getRequiredSignatures = contract => contract.methods.requiredSignatures().call()
 
 export const getValidatorCount = contract => contract.methods.validatorCount().call()
+
+export const getRequiredBlockConfirmations = async contract => {
+  const blockConfirmations = await contract.methods.requiredBlockConfirmations().call()
+  return parseInt(blockConfirmations)
+}
+
+export const getBridgeContract = contract => contract.methods.bridgeContract().call()


### PR DESCRIPTION
Closes #88 

Now the loading waits for the number of block confirmations set in the contracts in the `requiredBlockConfirmations` method. In the case of mediators, it will call that method from the related AMB bridge contract.

Updated the stake demo to include this change: https://stake-demo-5bffb.web.app/