### PR TITLE
Add old events processing in AMB monitor

### DIFF
--- a/monitor/checkWorker.js
+++ b/monitor/checkWorker.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const Web3 = require('web3')
 const logger = require('./logger')('checkWorker')
 const { getBridgeMode } = require('../commons')

--- a/monitor/checkWorker2.js
+++ b/monitor/checkWorker2.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const logger = require('./logger')('checkWorker2')
 const eventsStats = require('./eventsStats')
 const alerts = require('./alerts')

--- a/monitor/checkWorker3.js
+++ b/monitor/checkWorker3.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const Web3 = require('web3')
 const logger = require('./logger')('checkWorker3')
 const stuckTransfers = require('./stuckTransfers')


### PR DESCRIPTION
This PR should allow AMB monitor to process these old events as well:
```solidity
event UserRequestForSignature(bytes encodedData);
event UserRequestForAffirmation(bytes encodedData);
```