### PR TITLE
Get required block confirmation at the moment of the transaction

### DIFF
--- a/alm/src/components/ConfirmationsContainer.tsx
+++ b/alm/src/components/ConfirmationsContainer.tsx
@@ -11,6 +11,7 @@ import { getConfirmationsStatusDescription } from '../utils/networks'
 import { useStateProvider } from '../state/StateProvider'
 import { ExecutionConfirmation } from './ExecutionConfirmation'
 import { useValidatorContract } from '../hooks/useValidatorContract'
+import { useBlockConfirmations } from '../hooks/useBlockConfirmations'
 
 const StatusLabel = styled.label`
   font-weight: bold;
@@ -45,13 +46,15 @@ export const ConfirmationsContainer = ({ message, receipt, fromHome, timestamp }
     foreign: { name: foreignName }
   } = useStateProvider()
   const { requiredSignatures, validatorList } = useValidatorContract({ fromHome, receipt })
+  const { blockConfirmations } = useBlockConfirmations({ fromHome, receipt })
   const { confirmations, status, executionData, signatureCollected } = useMessageConfirmations({
     message,
     receipt,
     fromHome,
     timestamp,
     requiredSignatures,
-    validatorList
+    validatorList,
+    blockConfirmations
   })
 
   return (

--- a/alm/src/hooks/useBlockConfirmations.ts
+++ b/alm/src/hooks/useBlockConfirmations.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { TransactionReceipt } from 'web3-eth'
+import { useStateProvider } from '../state/StateProvider'
+import { Contract } from 'web3-eth-contract'
+import { getRequiredBlockConfirmations } from '../utils/contract'
+
+export interface UseBlockConfirmationsParams {
+  fromHome: boolean
+  receipt: Maybe<TransactionReceipt>
+}
+
+export const useBlockConfirmations = ({ receipt, fromHome }: UseBlockConfirmationsParams) => {
+  const [blockConfirmations, setBlockConfirmations] = useState(0)
+
+  const { home, foreign } = useStateProvider()
+
+  const callRequireBlockConfirmations = async (
+    contract: Contract,
+    receipt: TransactionReceipt,
+    setResult: Function
+  ) => {
+    const result = await getRequiredBlockConfirmations(contract, receipt.blockNumber)
+    setResult(result)
+  }
+
+  useEffect(
+    () => {
+      const bridgeContract = fromHome ? home.bridgeContract : foreign.bridgeContract
+      if (!bridgeContract || !receipt) return
+      callRequireBlockConfirmations(bridgeContract, receipt, setBlockConfirmations)
+    },
+    [home.bridgeContract, foreign.bridgeContract, receipt, fromHome]
+  )
+
+  return {
+    blockConfirmations
+  }
+}

--- a/alm/src/hooks/useBridgeContracts.ts
+++ b/alm/src/hooks/useBridgeContracts.ts
@@ -3,7 +3,6 @@ import { HOME_AMB_ABI, FOREIGN_AMB_ABI } from '../abis'
 import { FOREIGN_BRIDGE_ADDRESS, HOME_BRIDGE_ADDRESS } from '../config/constants'
 import { Contract } from 'web3-eth-contract'
 import Web3 from 'web3'
-import { getRequiredBlockConfirmations } from '../utils/contract'
 
 export interface useBridgeContractsParams {
   homeWeb3: Web3
@@ -13,20 +12,11 @@ export interface useBridgeContractsParams {
 export const useBridgeContracts = ({ homeWeb3, foreignWeb3 }: useBridgeContractsParams) => {
   const [homeBridge, setHomeBridge] = useState<Maybe<Contract>>(null)
   const [foreignBridge, setForeignBridge] = useState<Maybe<Contract>>(null)
-  const [homeBlockConfirmations, setHomeBlockConfirmations] = useState(0)
-  const [foreignBlockConfirmations, setForeignBlockConfirmations] = useState(0)
-
-  const callRequireBlockConfirmations = async (contract: Maybe<Contract>, setResult: Function) => {
-    if (!contract) return
-    const result = await getRequiredBlockConfirmations(contract)
-    setResult(result)
-  }
 
   useEffect(
     () => {
       if (!homeWeb3) return
       const homeContract = new homeWeb3.eth.Contract(HOME_AMB_ABI, HOME_BRIDGE_ADDRESS)
-      callRequireBlockConfirmations(homeContract, setHomeBlockConfirmations)
       setHomeBridge(homeContract)
     },
     [homeWeb3]
@@ -36,7 +26,6 @@ export const useBridgeContracts = ({ homeWeb3, foreignWeb3 }: useBridgeContracts
     () => {
       if (!foreignWeb3) return
       const foreignContract = new foreignWeb3.eth.Contract(FOREIGN_AMB_ABI, FOREIGN_BRIDGE_ADDRESS)
-      callRequireBlockConfirmations(foreignContract, setForeignBlockConfirmations)
       setForeignBridge(foreignContract)
     },
     [foreignWeb3]
@@ -44,8 +33,6 @@ export const useBridgeContracts = ({ homeWeb3, foreignWeb3 }: useBridgeContracts
 
   return {
     homeBridge,
-    foreignBridge,
-    homeBlockConfirmations,
-    foreignBlockConfirmations
+    foreignBridge
   }
 }

--- a/alm/src/state/StateProvider.tsx
+++ b/alm/src/state/StateProvider.tsx
@@ -18,7 +18,6 @@ export interface BaseNetworkParams {
   web3: Maybe<Web3>
   bridgeAddress: string
   bridgeContract: Maybe<Contract>
-  blockConfirmations: number
 }
 
 export interface StateContext {
@@ -33,16 +32,14 @@ const initialState = {
     name: '',
     web3: null,
     bridgeAddress: HOME_BRIDGE_ADDRESS,
-    bridgeContract: null,
-    blockConfirmations: 0
+    bridgeContract: null
   },
   foreign: {
     chainId: 0,
     name: '',
     web3: null,
     bridgeAddress: FOREIGN_BRIDGE_ADDRESS,
-    bridgeContract: null,
-    blockConfirmations: 0
+    bridgeContract: null
   },
   loading: true
 }
@@ -52,7 +49,7 @@ const StateContext = createContext<StateContext>(initialState)
 export const StateProvider = ({ children }: { children: ReactNode }) => {
   const homeNetwork = useNetwork(HOME_RPC_URL)
   const foreignNetwork = useNetwork(FOREIGN_RPC_URL)
-  const { homeBridge, foreignBridge, homeBlockConfirmations, foreignBlockConfirmations } = useBridgeContracts({
+  const { homeBridge, foreignBridge } = useBridgeContracts({
     homeWeb3: homeNetwork.web3,
     foreignWeb3: foreignNetwork.web3
   })
@@ -62,14 +59,12 @@ export const StateProvider = ({ children }: { children: ReactNode }) => {
       bridgeAddress: HOME_BRIDGE_ADDRESS,
       name: HOME_NETWORK_NAME,
       bridgeContract: homeBridge,
-      blockConfirmations: homeBlockConfirmations,
       ...homeNetwork
     },
     foreign: {
       bridgeAddress: FOREIGN_BRIDGE_ADDRESS,
       name: FOREIGN_NETWORK_NAME,
       bridgeContract: foreignBridge,
-      blockConfirmations: foreignBlockConfirmations,
       ...foreignNetwork
     },
     loading: homeNetwork.loading || foreignNetwork.loading


### PR DESCRIPTION
Closes #369 

It uses `RequiredBlockConfirmationChanged` evet to get the correct value.
For the deployment of the Sokol - Kovan AMB bridge, I found that we use an early version that didn't emit the event during initialization, so I added a special handling in case no events are found to use the current value.

Updated the demo to include these changes: https://alm-demo-e0998.web.app/