### PR TITLE
ALM docker improvements

### DIFF
--- a/alm/.env.example
+++ b/alm/.env.example
@@ -11,4 +11,4 @@ ALM_HOME_EXPLORER_TX_TEMPLATE=https://blockscout.com/poa/sokol/tx/%s
 ALM_FOREIGN_EXPLORER_TX_TEMPLATE=https://blockscout.com/eth/kovan/tx/%s
 
 ALM_HOME_EXPLORER_API=https://blockscout.com/poa/sokol/api
-ALM_FOREIGN_EXPLORER_API=https://kovan.etherscan.io/api
+ALM_FOREIGN_EXPLORER_API=https://kovan.etherscan.io/api?apikey=YourApiKeyToken

--- a/alm/.env.example
+++ b/alm/.env.example
@@ -12,4 +12,4 @@ ALM_FOREIGN_EXPLORER_TX_TEMPLATE=https://blockscout.com/eth/kovan/tx/%s
 
 ALM_HOME_EXPLORER_API=https://blockscout.com/poa/sokol/api
 ALM_FOREIGN_EXPLORER_API=https://kovan.etherscan.io/api?apikey=YourApiKeyToken
-ALM_PORT=8080
+PORT=8080

--- a/alm/.env.example
+++ b/alm/.env.example
@@ -12,3 +12,4 @@ ALM_FOREIGN_EXPLORER_TX_TEMPLATE=https://blockscout.com/eth/kovan/tx/%s
 
 ALM_HOME_EXPLORER_API=https://blockscout.com/poa/sokol/api
 ALM_FOREIGN_EXPLORER_API=https://kovan.etherscan.io/api?apikey=YourApiKeyToken
+ALM_PORT=8080

--- a/alm/Dockerfile
+++ b/alm/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12 as alm-builder
 
 WORKDIR /mono
 COPY package.json .
@@ -19,5 +19,11 @@ ARG DOT_ENV_PATH=./alm/.env
 COPY ${DOT_ENV_PATH} ./alm/.env
 
 WORKDIR /mono/alm
-CMD echo "To start the application run:" \
-  "yarn start"
+RUN yarn run build
+
+
+FROM node:12 as alm-production
+RUN yarn global add serve
+WORKDIR /app
+COPY --from=alm-builder /mono/alm/build .
+CMD echo "To start the application run: serve -p 8080 -s ."

--- a/alm/Dockerfile
+++ b/alm/Dockerfile
@@ -26,4 +26,4 @@ FROM node:12 as alm-production
 RUN yarn global add serve
 WORKDIR /app
 COPY --from=alm-builder /mono/alm/build .
-CMD echo "To start the application run: serve -p 8080 -s ."
+CMD serve -p $PORT -s .

--- a/alm/docker-compose.yml
+++ b/alm/docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ..
       dockerfile: alm/Dockerfile
     ports:
-      - "${ALM_PORT}:${ALM_PORT}"
+      - "${PORT}:${PORT}"
     env_file: ./.env
     environment: 
       - NODE_ENV=production
     restart: unless-stopped
-    entrypoint: serve -p ${ALM_PORT} -s .
+    entrypoint: serve -p ${PORT} -s .

--- a/alm/docker-compose.yml
+++ b/alm/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     build:
       context: ..
       dockerfile: alm/Dockerfile
+    ports:
+      - "${ALM_PORT}:${ALM_PORT}"
     env_file: ./.env
     environment: 
       - NODE_ENV=production
     restart: unless-stopped
-    entrypoint: yarn start
+    entrypoint: serve -p ${ALM_PORT} -s .

--- a/alm/package.json
+++ b/alm/package.json
@@ -26,7 +26,8 @@
     "react-scripts": "3.0.1",
     "styled-components": "^5.1.1",
     "typescript": "^3.5.2",
-    "web3": "1.2.7"
+    "web3": "1.2.7",
+    "web3-eth-contract": "1.2.7"
   },
   "scripts": {
     "start": "./load-env.sh react-app-rewired start",

--- a/alm/src/utils/explorer.ts
+++ b/alm/src/utils/explorer.ts
@@ -70,7 +70,7 @@ export const fetchAccountTransactionsFromBlockscout = async ({
 }
 
 export const getBlockByTimestampUrl = (api: string, timestamp: number) =>
-  `${api}?module=block&action=getblocknobytime&timestamp=${timestamp}&closest=before`
+  `${api}&module=block&action=getblocknobytime&timestamp=${timestamp}&closest=before`
 
 export const fetchAccountTransactionsFromEtherscan = async ({
   account,
@@ -101,7 +101,7 @@ export const fetchAccountTransactionsFromEtherscan = async ({
     return []
   }
 
-  const url = `${api}?module=account&action=txlist&address=${account}&startblock=${fromBlock}&endblock=${toBlock}`
+  const url = `${api}&module=account&action=txlist&address=${account}&startblock=${fromBlock}&endblock=${toBlock}`
 
   try {
     const result = await fetch(url).then(res => res.json())


### PR DESCRIPTION
This PR introduces the following changes:
- Fixes an error with web3 dependencies that caused the app to failed to compile using docker
- Allow specifying etherscan key. Example: `ALM_FOREIGN_EXPLORER_API=https://kovan.etherscan.io/api?apikey=YourApiKeyToken`
- Updated docker-compose file to bind ports. The new variable `PORT` is used for this.
- Updated Dockerfile to serve the production build of the app. This also allows reducing the size of the docker image to `~950MB`

Example of building and running with docker:
```
docker-compose build
```

And then
```
docker-compose up
```
or
```
docker run -ti -p 8080:8080 -e PORT=8080 --rm alm_alm:latest
```