### PR TITLE
Properly handle not found transaction and disable auto refresh

### DIFF
--- a/alm/src/components/Form.tsx
+++ b/alm/src/components/Form.tsx
@@ -35,8 +35,13 @@ export const Form = ({ onSubmit }: { onSubmit: ({ chainId, txHash, receipt }: Fo
     onSubmit({ chainId, txHash, receipt })
   }
 
+  const onBack = () => {
+    setTxHash('')
+    setSearchTx(false)
+  }
+
   if (searchTx) {
-    return <TransactionSelector txHash={txHash} onSelected={onSelected} />
+    return <TransactionSelector txHash={txHash} onSelected={onSelected} onBack={onBack} />
   }
 
   return (

--- a/alm/src/components/MainPage.tsx
+++ b/alm/src/components/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Route, useHistory } from 'react-router-dom'
 import { Form } from './Form'
@@ -63,6 +63,13 @@ export const MainPage = () => {
   const setNetworkFromParams = (chainId: number) => {
     setNetworkData(chainId)
   }
+
+  useEffect(() => {
+    const w = window as any
+    if (w.ethereum) {
+      w.ethereum.autoRefreshOnNetworkChange = false
+    }
+  }, [])
 
   return (
     <StyledMainPage>

--- a/alm/src/components/StatusContainer.tsx
+++ b/alm/src/components/StatusContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Link, useHistory, useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import { useTransactionStatus } from '../hooks/useTransactionStatus'
 import { formatTxHash, getExplorerTxUrl, getTransactionStatusDescription, validTxHash } from '../utils/networks'
 import { TRANSACTION_STATUS } from '../config/constants'
@@ -8,23 +8,8 @@ import { Loading } from './commons/Loading'
 import { useStateProvider } from '../state/StateProvider'
 import { ExplorerTxLink } from './commons/ExplorerTxLink'
 import { ConfirmationsContainer } from './ConfirmationsContainer'
-import { LeftArrow } from './commons/LeftArrow'
-import styled from 'styled-components'
 import { TransactionReceipt } from 'web3-eth'
-
-const BackButton = styled.button`
-  color: var(--button-color);
-  border-color: var(--font-color);
-  margin-top: 10px;
-  &:focus {
-    outline: var(--button-color);
-  }
-`
-
-const BackLabel = styled.label`
-  margin-left: 5px;
-  cursor: pointer;
-`
+import { BackButton } from './commons/BackButton'
 
 export interface StatusContainerParam {
   onBackToMain: () => void
@@ -107,16 +92,7 @@ export const StatusContainer = ({ onBackToMain, setNetworkFromParams, receiptPar
       {displayConfirmations && (
         <ConfirmationsContainer message={messageToConfirm} receipt={receipt} fromHome={isHome} timestamp={timestamp} />
       )}
-      <div className="row is-center">
-        <div className="col-9">
-          <Link to="/" onClick={onBackToMain}>
-            <BackButton className="button outline is-left">
-              <LeftArrow />
-              <BackLabel>Search another transaction</BackLabel>
-            </BackButton>
-          </Link>
-        </div>
-      </div>
+      <BackButton onBackToMain={onBackToMain} />
     </div>
   )
 }

--- a/alm/src/components/TransactionSelector.tsx
+++ b/alm/src/components/TransactionSelector.tsx
@@ -5,13 +5,18 @@ import { TRANSACTION_STATUS } from '../config/constants'
 import { TransactionReceipt } from 'web3-eth'
 import { Loading } from './commons/Loading'
 import { NetworkTransactionSelector } from './NetworkTransactionSelector'
+import { BackButton } from './commons/BackButton'
+import { TRANSACTION_STATUS_DESCRIPTION } from '../config/descriptions'
+import { MultiLine } from './commons/MultiLine'
 
 export const TransactionSelector = ({
   txHash,
-  onSelected
+  onSelected,
+  onBack
 }: {
   txHash: string
   onSelected: (chainId: number, receipt: TransactionReceipt) => void
+  onBack: () => void
 }) => {
   const { home, foreign } = useStateProvider()
   const { receipt: homeReceipt, status: homeStatus } = useTransactionFinder({ txHash, web3: home.web3 })
@@ -41,6 +46,16 @@ export const TransactionSelector = ({
 
   if (foreignStatus === TRANSACTION_STATUS.FOUND && homeStatus === TRANSACTION_STATUS.FOUND) {
     return <NetworkTransactionSelector onNetworkSelected={onSelectedNetwork} />
+  }
+
+  if (foreignStatus === TRANSACTION_STATUS.NOT_FOUND && homeStatus === TRANSACTION_STATUS.NOT_FOUND) {
+    const message = TRANSACTION_STATUS_DESCRIPTION[TRANSACTION_STATUS.NOT_FOUND]
+    return (
+      <div>
+        <MultiLine>{message}</MultiLine>
+        <BackButton onBackToMain={onBack} />
+      </div>
+    )
   }
 
   return <Loading />

--- a/alm/src/components/TransactionSelector.tsx
+++ b/alm/src/components/TransactionSelector.tsx
@@ -8,6 +8,11 @@ import { NetworkTransactionSelector } from './NetworkTransactionSelector'
 import { BackButton } from './commons/BackButton'
 import { TRANSACTION_STATUS_DESCRIPTION } from '../config/descriptions'
 import { MultiLine } from './commons/MultiLine'
+import styled from 'styled-components'
+
+const StyledMultiLine = styled(MultiLine)`
+  margin-bottom: 40px;
+`
 
 export const TransactionSelector = ({
   txHash,
@@ -52,7 +57,7 @@ export const TransactionSelector = ({
     const message = TRANSACTION_STATUS_DESCRIPTION[TRANSACTION_STATUS.NOT_FOUND]
     return (
       <div>
-        <MultiLine>{message}</MultiLine>
+        <StyledMultiLine>{message}</StyledMultiLine>
         <BackButton onBackToMain={onBack} />
       </div>
     )

--- a/alm/src/components/commons/BackButton.tsx
+++ b/alm/src/components/commons/BackButton.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom'
+import { LeftArrow } from './LeftArrow'
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledButton = styled.button`
+  color: var(--button-color);
+  border-color: var(--font-color);
+  margin-top: 10px;
+  &:focus {
+    outline: var(--button-color);
+  }
+`
+
+const BackLabel = styled.label`
+  margin-left: 5px;
+  cursor: pointer;
+`
+
+export interface BackButtonParam {
+  onBackToMain: () => void
+}
+
+export const BackButton = ({ onBackToMain }: BackButtonParam) => (
+  <div className="row is-center">
+    <div className="col-9">
+      <Link to="/" onClick={onBackToMain}>
+        <StyledButton className="button outline is-left">
+          <LeftArrow />
+          <BackLabel>Search another transaction</BackLabel>
+        </StyledButton>
+      </Link>
+    </div>
+  </div>
+)

--- a/alm/src/components/commons/MultiLine.tsx
+++ b/alm/src/components/commons/MultiLine.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components'
+
+export const MultiLine = styled.div`
+  white-space: pre-wrap;
+`

--- a/alm/src/config/descriptions.ts
+++ b/alm/src/config/descriptions.ts
@@ -4,7 +4,8 @@ export const TRANSACTION_STATUS_DESCRIPTION: { [key: string]: string } = {
   SUCCESS_ONE_MESSAGE: 'was initiated %t',
   SUCCESS_NO_MESSAGES: 'execution succeeded %t but it does not contain any bridge messages',
   FAILED: 'failed %t',
-  NOT_FOUND: 'was not found'
+  NOT_FOUND:
+    'Transaction not found. \n1. Check that the transaction hash is correct. \n2. Wait several blocks for the transaction to be\nmined, gas price affects mining speed.'
 }
 
 export const CONFIRMATIONS_STATUS_LABEL: { [key: string]: string } = {


### PR DESCRIPTION
This PR includes 2 fixes:
- Display the correct message and back button if transaction not found. Closes #392 
- Disable auto refresh feature from injected wallets. Closes #393 

Demo updated: https://alm-demo-e0998.web.app/