### PR TITLE
Update ALM logic to continue displaying failed signatures from validators

### DIFF
--- a/alm/src/hooks/useMessageConfirmations.ts
+++ b/alm/src/hooks/useMessageConfirmations.ts
@@ -313,7 +313,7 @@ export const useMessageConfirmations = ({
   // Sets the message status based in the collected information
   useEffect(
     () => {
-      if (executionData.status === VALIDATOR_CONFIRMATION_STATUS.SUCCESS) {
+      if (executionData.status === VALIDATOR_CONFIRMATION_STATUS.SUCCESS && existsConfirmation(confirmations)) {
         const newStatus = executionData.executionResult
           ? CONFIRMATIONS_STATUS.SUCCESS
           : CONFIRMATIONS_STATUS.SUCCESS_MESSAGE_FAILED

--- a/alm/src/services/BlockNumberProvider.ts
+++ b/alm/src/services/BlockNumberProvider.ts
@@ -33,7 +33,7 @@ export class BlockNumberProvider {
   }
 
   stop() {
-    this.running = this.running - 1
+    this.running = this.running > 0 ? this.running - 1 : 0
 
     if (!this.running) {
       clearTimeout(this.ref)


### PR DESCRIPTION
Closes #390 

This PR also contains a fix on the block number provider service that was causing the app to freeze on some occasions when waiting for block confirmations. https://github.com/poanetwork/tokenbridge/commit/182c30d8c01545466c311e523223d5e540f3c038

Updated demo: https://alm-demo-e0998.web.app/