### PR TITLE
Correctly set a validator status as not required

### DIFF
--- a/alm/src/utils/getConfirmationsForTx.ts
+++ b/alm/src/utils/getConfirmationsForTx.ts
@@ -118,7 +118,10 @@ export const getConfirmationsForTx = async (
       status: VALIDATOR_CONFIRMATION_STATUS.NOT_REQUIRED
     }))
 
-    validatorConfirmations = [...validatorConfirmations, ...notRequiredConfirmations]
+    notRequiredConfirmations.forEach(validatorData => {
+      const index = validatorConfirmations.findIndex(e => e.validator === validatorData.validator)
+      validatorConfirmations[index] = validatorData
+    })
     signatureCollectedResult = true
   }
 


### PR DESCRIPTION
Closes #409 

After reproducing the issue and looking for the cause, I found that the `Not Required` label wasn't being set correctly and that's why the `Waiting` status wasn't updated.

Updated the demo page: https://alm-demo-e0998.web.app/42/0x3a1da17b08d41fa390f02379c8a8d87ce77991328c581dec61c73bbce07004d4