### PR TITLE
Correction of the message for a transaction without the bridge requests

### DIFF
--- a/alm/src/components/StatusContainer.tsx
+++ b/alm/src/components/StatusContainer.tsx
@@ -7,6 +7,7 @@ import { MessageSelector } from './MessageSelector'
 import { Loading } from './commons/Loading'
 import { useStateProvider } from '../state/StateProvider'
 import { ExplorerTxLink } from './commons/ExplorerTxLink'
+import { MultiLine } from './commons/MultiLine'
 import { ConfirmationsContainer } from './ConfirmationsContainer'
 import { TransactionReceipt } from 'web3-eth'
 import { BackButton } from './commons/BackButton'
@@ -64,10 +65,6 @@ export const StatusContainer = ({ onBackToMain, setNetworkFromParams, receiptPar
   const displayReference = multiMessageSelected ? messages[selectedMessageId].id : txHash
   const formattedMessageId = formatTxHash(displayReference)
 
-  const displayedDescription = multiMessageSelected
-    ? getTransactionStatusDescription(TRANSACTION_STATUS.SUCCESS_ONE_MESSAGE, timestamp)
-    : description
-
   const isHome = chainId === home.chainId.toString()
   const txExplorerLink = getExplorerTxUrl(txHash, isHome)
   const displayExplorerLink = status !== TRANSACTION_STATUS.NOT_FOUND
@@ -75,17 +72,32 @@ export const StatusContainer = ({ onBackToMain, setNetworkFromParams, receiptPar
   const displayConfirmations = status === TRANSACTION_STATUS.SUCCESS_ONE_MESSAGE || multiMessageSelected
   const messageToConfirm =
     messages.length > 1 ? messages[selectedMessageId] : messages.length > 0 ? messages[0] : { id: '', data: '' }
+
+  let displayedDescription:string = multiMessageSelected
+      ? getTransactionStatusDescription(TRANSACTION_STATUS.SUCCESS_ONE_MESSAGE, timestamp)
+      : description
+  let link
+  const descArray = displayedDescription.split('%link')
+  if (descArray.length > 1) {
+    displayedDescription = descArray[0]
+    link = (
+      <ExplorerTxLink href={descArray[1]} target="_blank" rel="noopener noreferrer">
+        {descArray[1]}
+      </ExplorerTxLink>
+    )
+  }
+
   return (
     <div>
       {status && (
         <p>
-          The request{' '}
+          The transaction{' '}
           {displayExplorerLink && (
             <ExplorerTxLink href={txExplorerLink} target="_blank">
               {formattedMessageId}
             </ExplorerTxLink>
           )}
-          {!displayExplorerLink && <label>{formattedMessageId}</label>} {displayedDescription}
+          {!displayExplorerLink && <label>{formattedMessageId}</label>} {displayedDescription} {link}
         </p>
       )}
       {displayMessageSelector && <MessageSelector messages={messages} onMessageSelected={onMessageSelected} />}

--- a/alm/src/components/StatusContainer.tsx
+++ b/alm/src/components/StatusContainer.tsx
@@ -7,7 +7,6 @@ import { MessageSelector } from './MessageSelector'
 import { Loading } from './commons/Loading'
 import { useStateProvider } from '../state/StateProvider'
 import { ExplorerTxLink } from './commons/ExplorerTxLink'
-import { MultiLine } from './commons/MultiLine'
 import { ConfirmationsContainer } from './ConfirmationsContainer'
 import { TransactionReceipt } from 'web3-eth'
 import { BackButton } from './commons/BackButton'
@@ -73,9 +72,9 @@ export const StatusContainer = ({ onBackToMain, setNetworkFromParams, receiptPar
   const messageToConfirm =
     messages.length > 1 ? messages[selectedMessageId] : messages.length > 0 ? messages[0] : { id: '', data: '' }
 
-  let displayedDescription:string = multiMessageSelected
-      ? getTransactionStatusDescription(TRANSACTION_STATUS.SUCCESS_ONE_MESSAGE, timestamp)
-      : description
+  let displayedDescription: string = multiMessageSelected
+    ? getTransactionStatusDescription(TRANSACTION_STATUS.SUCCESS_ONE_MESSAGE, timestamp)
+    : description
   let link
   const descArray = displayedDescription.split('%link')
   if (descArray.length > 1) {

--- a/alm/src/config/descriptions.ts
+++ b/alm/src/config/descriptions.ts
@@ -2,7 +2,8 @@
 export const TRANSACTION_STATUS_DESCRIPTION: { [key: string]: string } = {
   SUCCESS_MULTIPLE_MESSAGES: 'was initiated %t and contains several bridge messages. Specify one of them:',
   SUCCESS_ONE_MESSAGE: 'was initiated %t',
-  SUCCESS_NO_MESSAGES: 'successfully mined %t but it does not seem to contain any request to the bridge, \nso nothing needs to be confirmed by the validators. \nIf you are sure that the transaction should contain a request to the bridge,\ncontact to the validators by \nmessaging on %linkhttps://forum.poa.network/c/support',
+  SUCCESS_NO_MESSAGES:
+    'successfully mined %t but it does not seem to contain any request to the bridge, \nso nothing needs to be confirmed by the validators. \nIf you are sure that the transaction should contain a request to the bridge,\ncontact to the validators by \nmessaging on %linkhttps://forum.poa.network/c/support',
   FAILED: 'failed %t',
   NOT_FOUND:
     'Transaction not found. \n1. Check that the transaction hash is correct. \n2. Wait several blocks for the transaction to be\nmined, gas price affects mining speed.'

--- a/alm/src/config/descriptions.ts
+++ b/alm/src/config/descriptions.ts
@@ -2,7 +2,7 @@
 export const TRANSACTION_STATUS_DESCRIPTION: { [key: string]: string } = {
   SUCCESS_MULTIPLE_MESSAGES: 'was initiated %t and contains several bridge messages. Specify one of them:',
   SUCCESS_ONE_MESSAGE: 'was initiated %t',
-  SUCCESS_NO_MESSAGES: 'execution succeeded %t but it does not contain any bridge messages',
+  SUCCESS_NO_MESSAGES: 'successfully mined %t but it does not seem to contain any request to the bridge. \nNothing needs to be confirmed by the validators. \nIf you are sure that the transaction should contain a request to the bridge,\ncontact to the validators by \nmessaging on %linkhttps://forum.poa.network/c/support',
   FAILED: 'failed %t',
   NOT_FOUND:
     'Transaction not found. \n1. Check that the transaction hash is correct. \n2. Wait several blocks for the transaction to be\nmined, gas price affects mining speed.'

--- a/alm/src/config/descriptions.ts
+++ b/alm/src/config/descriptions.ts
@@ -2,7 +2,7 @@
 export const TRANSACTION_STATUS_DESCRIPTION: { [key: string]: string } = {
   SUCCESS_MULTIPLE_MESSAGES: 'was initiated %t and contains several bridge messages. Specify one of them:',
   SUCCESS_ONE_MESSAGE: 'was initiated %t',
-  SUCCESS_NO_MESSAGES: 'successfully mined %t but it does not seem to contain any request to the bridge. \nNothing needs to be confirmed by the validators. \nIf you are sure that the transaction should contain a request to the bridge,\ncontact to the validators by \nmessaging on %linkhttps://forum.poa.network/c/support',
+  SUCCESS_NO_MESSAGES: 'successfully mined %t but it does not seem to contain any request to the bridge, \nso nothing needs to be confirmed by the validators. \nIf you are sure that the transaction should contain a request to the bridge,\ncontact to the validators by \nmessaging on %linkhttps://forum.poa.network/c/support',
   FAILED: 'failed %t',
   NOT_FOUND:
     'Transaction not found. \n1. Check that the transaction hash is correct. \n2. Wait several blocks for the transaction to be\nmined, gas price affects mining speed.'


### PR DESCRIPTION
These changes are needed to get rid of an ambiguity for the case when the transaction was sent to the bridge but did not initiate a bridge message by some reason.

![image](https://user-images.githubusercontent.com/20793260/89439040-48fc3600-d752-11ea-939d-cddc3dfd6f9f.png)
