### PR TITLE
fix bug with method handler crashed

### DIFF
--- a/oracle/src/events/processSignatureRequests/estimateGas.js
+++ b/oracle/src/events/processSignatureRequests/estimateGas.js
@@ -3,6 +3,9 @@ const { AlreadyProcessedError, AlreadySignedError, InvalidValidatorError } = req
 const logger = require('../../services/logger').child({
   module: 'processSignatureRequests:estimateGas'
 })
+const {
+  FALLBACK_GAS_ESTIMATE
+} = require('../../utils/constants')
 
 async function estimateGas({ web3, homeBridge, validatorContract, signature, message, address }) {
   try {
@@ -16,11 +19,7 @@ async function estimateGas({ web3, homeBridge, validatorContract, signature, mes
     }
     if (e.message.includes('method handler crashed')){
       logger.debug('Method handler crashed error. Return constant estimateGas')
-      const msgGasLimit = parseAMBHeader(message).gasLimit
-      // message length in bytes
-      const len = strip0x(message).length / 2 - MIN_AMB_HEADER_LENGTH
-
-      return FALLBACK_GAS_ESTIMATE + msgGasLimit + estimateExtraGas(len)
+      return FALLBACK_GAS_ESTIMATE
     }
 
     // Check if minimum number of validations was already reached

--- a/oracle/src/events/processSignatureRequests/estimateGas.js
+++ b/oracle/src/events/processSignatureRequests/estimateGas.js
@@ -14,6 +14,14 @@ async function estimateGas({ web3, homeBridge, validatorContract, signature, mes
     if (e instanceof HttpListProviderError) {
       throw e
     }
+    if (e.message.includes('method handler crashed')){
+      logger.debug('Method handler crashed error. Return constant estimateGas')
+      const msgGasLimit = parseAMBHeader(message).gasLimit
+      // message length in bytes
+      const len = strip0x(message).length / 2 - MIN_AMB_HEADER_LENGTH
+
+      return FALLBACK_GAS_ESTIMATE + msgGasLimit + estimateExtraGas(len)
+    }
 
     // Check if minimum number of validations was already reached
     logger.debug('Check if minimum number of validations was reached')

--- a/oracle/src/utils/constants.js
+++ b/oracle/src/utils/constants.js
@@ -22,5 +22,6 @@ module.exports = {
   GAS_PRICE_BOUNDARIES: {
     MIN: 1,
     MAX: 250
-  }
+  },
+  FALLBACK_GAS_ESTIMATE: 600000
 }


### PR DESCRIPTION
- added MIN_AMB_HEADER_LENGTH to constants.js
- returns constant gas limit for executeAffirmation and submitSignature in case of `method handler crashed` 