### PR TITLE
Change used RPC URLs delimiter to space

### DIFF
--- a/oracle/src/services/RpcUrlsManager.js
+++ b/oracle/src/services/RpcUrlsManager.js
@@ -11,8 +11,8 @@ function RpcUrlsManager(homeUrls, foreignUrls) {
     throw new Error(`Invalid foreignUrls: '${foreignUrls}'`)
   }
 
-  this.homeUrls = homeUrls.split(',')
-  this.foreignUrls = foreignUrls.split(',')
+  this.homeUrls = homeUrls.split(' ')
+  this.foreignUrls = foreignUrls.split(' ')
 }
 
 RpcUrlsManager.prototype.tryEach = async function(chain, f, redundant = false) {


### PR DESCRIPTION
During the deployment of the bridge with the ansible playbooks it was found that the URLs delimiters in the RPC endpoint list is not consistent with the rest of configuration parameters where the space is used as separator of two elements of the list. 