### PR TITLE
Centralized handling all collected signatures requests

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -22,7 +22,7 @@ COMMON_FOREIGN_GAS_PRICE_FACTOR | A value that will multiply the gas price of th
 
 name | description | value
 --- | --- | ---
-ORACLE_BRIDGE_MODE | The bridge mode. The bridge starts listening to a different set of events based on this parameter. | NATIVE_TO_ERC / ERC_TO_ERC / ERC_TO_NATIVE
+ORACLE_BRIDGE_MODE | The bridge mode. The bridge starts listening to a different set of events based on this parameter. | NATIVE_TO_ERC / ERC_TO_ERC / ERC_TO_NATIVE / ARBITRARY_MESSAGE
 ORACLE_ALLOW_HTTP_FOR_RPC | **Only use in test environments - must be omitted in production environments.**. If this parameter is specified and set to `yes`, RPC URLs can be specified in form of HTTP links. A warning that the connection is insecure will be written to the logs. | `yes` / `no`
 ORACLE_HOME_RPC_POLLING_INTERVAL | The interval in milliseconds used to request the RPC node in the Home network for new blocks. The interval should match the average production time for a new block. | integer
 ORACLE_FOREIGN_RPC_POLLING_INTERVAL | The interval in milliseconds used to request the RPC node in the Foreign network for new blocks. The interval should match the average production time for a new block. | integer
@@ -40,6 +40,7 @@ ORACLE_TX_REDUNDANCY | If set to `true`, instructs oracle to send `eth_sendRawTr
 ORACLE_HOME_TO_FOREIGN_ALLOWANCE_LIST | Filename with a list of addresses, separated by newlines. If set, determines the privileged set of accounts whose requests will be automatically processed by the CollectedSignatures watcher. | string
 ORACLE_HOME_TO_FOREIGN_BLOCK_LIST | Filename with a list of addresses, separated by newlines. If set, determines the blocked set of accounts whose requests will not be automatically processed by the CollectedSignatures watcher. Has a lower priority than the `ORACLE_HOME_TO_FOREIGN_ALLOWANCE_LIST` | string
 ORACLE_HOME_TO_FOREIGN_CHECK_SENDER | If set to `true`, instructs the oracle to do an extra check for transaction origin in the block/allowance list. `false` by default. | `true` / `false`
+ORACLE_ALWAYS_RELAY_SIGNATURES | If set to `true`, the oracle will always relay signatures even if it was not the last who finilized the signatures collecting process. The default is `false`. | `true` / `false`
 
 
 ## UI configuration

--- a/oracle/src/events/processAMBCollectedSignatures/index.js
+++ b/oracle/src/events/processAMBCollectedSignatures/index.js
@@ -12,9 +12,7 @@ const { MAX_CONCURRENT_EVENTS, EXTRA_GAS_ABSOLUTE } = require('../../utils/const
 
 const limit = promiseLimit(MAX_CONCURRENT_EVENTS)
 
-const {
-  ORACLE_ALWAYS_RELAY_SIGNATURES
-} = process.env
+const { ORACLE_ALWAYS_RELAY_SIGNATURES } = process.env
 
 let validatorContract = null
 

--- a/oracle/src/events/processAMBCollectedSignatures/index.js
+++ b/oracle/src/events/processAMBCollectedSignatures/index.js
@@ -12,6 +12,10 @@ const { MAX_CONCURRENT_EVENTS, EXTRA_GAS_ABSOLUTE } = require('../../utils/const
 
 const limit = promiseLimit(MAX_CONCURRENT_EVENTS)
 
+const {
+  ORACLE_ALWAYS_RELAY_SIGNATURES
+} = process.env
+
 let validatorContract = null
 
 function processCollectedSignaturesBuilder(config) {
@@ -39,7 +43,9 @@ function processCollectedSignaturesBuilder(config) {
           eventTransactionHash: colSignature.transactionHash
         })
 
-        if (authorityResponsibleForRelay !== web3Home.utils.toChecksumAddress(config.validatorAddress)) {
+        if (ORACLE_ALWAYS_RELAY_SIGNATURES && ORACLE_ALWAYS_RELAY_SIGNATURES === 'true') {
+          logger.debug('Validator handles all CollectedSignature requests')
+        } else if (authorityResponsibleForRelay !== web3Home.utils.toChecksumAddress(config.validatorAddress)) {
           logger.info(`Validator not responsible for relaying CollectedSignatures ${colSignature.transactionHash}`)
           return
         }

--- a/oracle/src/events/processCollectedSignatures/index.js
+++ b/oracle/src/events/processCollectedSignatures/index.js
@@ -46,13 +46,11 @@ function processCollectedSignaturesBuilder(config) {
           eventTransactionHash: colSignature.transactionHash
         })
 
-        if (ORACLE_ALWAYS_RELAY_SIGNATURES && (ORACLE_ALWAYS_RELAY_SIGNATURES === 'true')) {
-          logger.debug("Validator handles all CollectedSignature requests")
-        } else {
-          if (authorityResponsibleForRelay !== web3Home.utils.toChecksumAddress(config.validatorAddress)) {
+        if (ORACLE_ALWAYS_RELAY_SIGNATURES && ORACLE_ALWAYS_RELAY_SIGNATURES === 'true') {
+          logger.debug('Validator handles all CollectedSignature requests')
+        } else if (authorityResponsibleForRelay !== web3Home.utils.toChecksumAddress(config.validatorAddress)) {
             logger.info(`Validator not responsible for relaying CollectedSignatures ${colSignature.transactionHash}`)
             return
-          }
         }
 
         logger.info(`Processing CollectedSignatures ${colSignature.transactionHash}`)

--- a/oracle/src/events/processCollectedSignatures/index.js
+++ b/oracle/src/events/processCollectedSignatures/index.js
@@ -49,8 +49,8 @@ function processCollectedSignaturesBuilder(config) {
         if (ORACLE_ALWAYS_RELAY_SIGNATURES && ORACLE_ALWAYS_RELAY_SIGNATURES === 'true') {
           logger.debug('Validator handles all CollectedSignature requests')
         } else if (authorityResponsibleForRelay !== web3Home.utils.toChecksumAddress(config.validatorAddress)) {
-            logger.info(`Validator not responsible for relaying CollectedSignatures ${colSignature.transactionHash}`)
-            return
+          logger.info(`Validator not responsible for relaying CollectedSignatures ${colSignature.transactionHash}`)
+          return
         }
 
         logger.info(`Processing CollectedSignatures ${colSignature.transactionHash}`)

--- a/oracle/src/events/processCollectedSignatures/index.js
+++ b/oracle/src/events/processCollectedSignatures/index.js
@@ -13,7 +13,8 @@ const { MAX_CONCURRENT_EVENTS } = require('../../utils/constants')
 const {
   ORACLE_HOME_TO_FOREIGN_ALLOWANCE_LIST,
   ORACLE_HOME_TO_FOREIGN_BLOCK_LIST,
-  ORACLE_HOME_TO_FOREIGN_CHECK_SENDER
+  ORACLE_HOME_TO_FOREIGN_CHECK_SENDER,
+  ORACLE_ALWAYS_RELAY_SIGNATURES
 } = process.env
 
 const limit = promiseLimit(MAX_CONCURRENT_EVENTS)
@@ -45,9 +46,13 @@ function processCollectedSignaturesBuilder(config) {
           eventTransactionHash: colSignature.transactionHash
         })
 
-        if (authorityResponsibleForRelay !== web3Home.utils.toChecksumAddress(config.validatorAddress)) {
-          logger.info(`Validator not responsible for relaying CollectedSignatures ${colSignature.transactionHash}`)
-          return
+        if (ORACLE_ALWAYS_RELAY_SIGNATURES && (ORACLE_ALWAYS_RELAY_SIGNATURES === 'true')) {
+          logger.debug("Validator handles all CollectedSignature requests")
+        } else {
+          if (authorityResponsibleForRelay !== web3Home.utils.toChecksumAddress(config.validatorAddress)) {
+            logger.info(`Validator not responsible for relaying CollectedSignatures ${colSignature.transactionHash}`)
+            return
+          }
         }
 
         logger.info(`Processing CollectedSignatures ${colSignature.transactionHash}`)


### PR DESCRIPTION
Currently the oracle that sends the finalising signature is responsible for transferring all the signatures to the Foreign chain to finalize the bridge requests originating in the Home chain. Sometimes (e.g. few oracles has no enough funds for the account in the Foreign chain), it is useful to allow one oracle to handle all CollectedSignatures events.