### PR TITLE
Update requirements for higher bound of gas price

### DIFF
--- a/oracle/src/utils/constants.js
+++ b/oracle/src/utils/constants.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   GAS_PRICE_BOUNDARIES: {
     MIN: 1,
-    MAX: 250
+    MAX: 1000
   },
   TRANSACTION_RESEND_TIMEOUT: 20 * 60 * 1000,
   SENDER_QUEUE_MAX_PRIORITY: 10,


### PR DESCRIPTION
Analysis of the transactions made in the Ethereum Mainnet in August and September of 2020 shows that the gas price could be much higher than the current higher bound -- 250 gwei. Due to this limit the oracles transactions were minted with significant delays.