### PR TITLE
Get rid of "Given nonce value is not a valid number" in the logs

### DIFF
--- a/oracle/src/sender.js
+++ b/oracle/src/sender.js
@@ -194,8 +194,10 @@ async function main({ msg, ackMsg, nackMsg, channel, scheduleForRetry, scheduleT
       }
     })
 
-    logger.debug('Updating nonce')
-    await updateNonce(nonce)
+    if (typeof nonce === 'number') {
+      logger.debug('Updating nonce')
+      await updateNonce(nonce)
+    }
 
     if (failedTx.length) {
       logger.info(`Sending ${failedTx.length} Failed Tx to Queue`)


### PR DESCRIPTION
In order to get rid of logs like "Given nonce value is not a valid number. Nothing will be updated in the DB." the nonce value is checked before the function `updateNonce` is called. Similar check with the function `updateNonce` is not removed for future usage if it is called from another place in the code.