### PR TITLE
Reduce time complexity of monitor

### DIFF
--- a/monitor/utils/message.js
+++ b/monitor/utils/message.js
@@ -1,44 +1,27 @@
-const web3Utils = require('web3').utils
 const { parseAMBMessage } = require('../../commons')
 
-function deliveredMsgNotProcessed(processedList) {
-  return deliveredMsg => {
-    let msgData = deliveredMsg.returnValues.encodedData
-    if (!deliveredMsg.returnValues.messageId) {
-      // append tx hash to an old message, where message id was not used
-      msgData = deliveredMsg.transactionHash + msgData.slice(2)
-    }
-    const msg = parseAMBMessage(msgData)
-    return (
-      processedList.filter(processedMsg => {
-        return messageEqualsEvent(msg, processedMsg.returnValues)
-      }).length === 0
-    )
+const keyAMB = e => [e.messageId, e.sender, e.executor].join(',').toLowerCase()
+
+const normalizeAMBMessage = e => {
+  let msgData = e.returnValues.encodedData
+  if (!e.returnValues.messageId) {
+    // append tx hash to an old message, where message id was not used
+    // for old messages, e.messageId is a corresponding transactionHash
+    msgData = e.transactionHash + msgData.slice(2)
   }
+  return parseAMBMessage(msgData)
+}
+
+function deliveredMsgNotProcessed(processedList) {
+  const keys = new Set()
+  processedList.forEach(processedMsg => keys.add(keyAMB(processedMsg.returnValues)))
+  return deliveredMsg => !keys.has(keyAMB(normalizeAMBMessage(deliveredMsg)))
 }
 
 function processedMsgNotDelivered(deliveredList) {
-  return processedMsg => {
-    return (
-      deliveredList.filter(deliveredMsg => {
-        let msgData = deliveredMsg.returnValues.encodedData
-        if (!deliveredMsg.returnValues.messageId) {
-          // append tx hash to an old message, where message id was not used
-          msgData = deliveredMsg.transactionHash + msgData.slice(2)
-        }
-        const msg = parseAMBMessage(msgData)
-        return messageEqualsEvent(msg, processedMsg.returnValues)
-      }).length === 0
-    )
-  }
-}
-
-function messageEqualsEvent(parsedMsg, event) {
-  return (
-    web3Utils.toChecksumAddress(parsedMsg.sender) === event.sender &&
-    web3Utils.toChecksumAddress(parsedMsg.executor) === event.executor &&
-    parsedMsg.messageId === event.messageId // for an old messages, event.messageId is actually a transactionHash
-  )
+  const keys = new Set()
+  deliveredList.forEach(deliveredMsg => keys.add(keyAMB(normalizeAMBMessage(deliveredMsg))))
+  return processedMsg => !keys.has(keyAMB(processedMsg.returnValues))
 }
 
 /**
@@ -60,9 +43,13 @@ const normalizeEventInformation = event => ({
   value: event.returnValues.value
 })
 
-const eventWithoutReference = otherSideEvents => e =>
-  otherSideEvents.filter(a => a.referenceTx === e.referenceTx && a.recipient === e.recipient && a.value === e.value)
-    .length === 0
+const key = e => [e.referenceTx, e.recipient, e.value].join(',').toLowerCase()
+
+const eventWithoutReference = otherSideEvents => {
+  const keys = new Set()
+  otherSideEvents.forEach(e => keys.add(key(e)))
+  return e => !keys.has(key(e))
+}
 
 module.exports = {
   deliveredMsgNotProcessed,


### PR DESCRIPTION
This PR reduces the time complexity for events processing from `O(n^2)` to `O(n)`. Unneeded `keccak256` operations were replaced by case insensitive comparisons as well for the sake of performance .