### PR TITLE
Fix set-env deprecation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: git submodule status > submodule.status
-      - id: get_cache_key
-        run: echo "::set-output name=cache_key::cache-repo-${{ hashFiles('yarn.lock', 'package.json', 'submodule.status') }}"
+      - name: Set cache key
+        id: get_cache_key
+        run: |
+          git submodule status > submodule.status
+          echo "::set-output name=cache_key::cache-repo-${{ hashFiles('yarn.lock', 'package.json', 'submodule.status') }}"
       - uses: actions/cache@v2
         id: cache-repo
         with:
@@ -29,7 +31,8 @@ jobs:
             **/node_modules
             contracts/build
           key: ${{ steps.get_cache_key.outputs.cache_key }}
-      - if: ${{ !steps.cache-repo.outputs.cache-hit }}
+      - name: Install dependencies and compile contracts
+        if: ${{ !steps.cache-repo.outputs.cache-hit }}
         run: |
           yarn install --frozen-lockfile
           yarn run install:deploy
@@ -56,7 +59,8 @@ jobs:
             **/node_modules
             contracts/build
           key: ${{ needs.initialize.outputs.cache_key }}
-      - run: ${{ steps.cache-repo.outputs.cache-hit }} && yarn run ${{ matrix.task }}
+      - name: yarn run ${{ matrix.task }}
+        run: ${{ steps.cache-repo.outputs.cache-hit }} && yarn run ${{ matrix.task }}
   ui-coverage:
     runs-on: ubuntu-latest
     needs:
@@ -76,7 +80,8 @@ jobs:
             **/node_modules
             contracts/build
           key: ${{ needs.initialize.outputs.cache_key }}
-      - run: ${{ steps.cache-repo.outputs.cache-hit }} && yarn workspace ui run coverage
+      - name: yarn workspace ui run coverage
+        run: ${{ steps.cache-repo.outputs.cache-hit }} && yarn workspace ui run coverage
       - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ github.token }}
@@ -87,14 +92,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: |
+      - name: Evaluate e2e docker images tags
+        run: |
           git submodule status > submodule.status
-          echo "::set-env name=E2E_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'Dockerfile.e2e', 'commons', 'oracle-e2e', 'monitor-e2e') }}"
-          echo "::set-env name=ORACLE_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'oracle') }}"
-          echo "::set-env name=MONITOR_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'monitor') }}"
-          echo "::set-env name=UI_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'ui') }}"
-          echo "::set-env name=ALM_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'alm') }}"
-      - run: |
+          echo "E2E_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'Dockerfile.e2e', 'commons', 'oracle-e2e', 'monitor-e2e') }}" >> $GITHUB_ENV
+          echo "ORACLE_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'oracle') }}" >> $GITHUB_ENV
+          echo "MONITOR_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'monitor') }}" >> $GITHUB_ENV
+          echo "UI_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'ui') }}" >> $GITHUB_ENV
+          echo "ALM_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'alm') }}" >> $GITHUB_ENV
+      - name: Rebuild and push updated images
+        run: |
           function check_if_image_exists() {
             curl -fsSlL -H 'Authorization: bearer ${{ github.token }}' "https://${DOCKER_REGISTRY}/v2/${DOCKER_REPO}/tokenbridge-e2e-$1/manifests/$2" > /dev/null
           }
@@ -119,8 +126,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: echo "::set-env name=MOLECULE_RUNNER_TAG::${{ hashFiles('./deployment-e2e/Dockerfile') }}"
-      - run: |
+      - name: Evaluate e2e molecule runner tag
+        run: echo "MOLECULE_RUNNER_TAG=${{ hashFiles('./deployment-e2e/Dockerfile') }}" >> $GITHUB_ENV
+      - name: Rebuild and push molecule runner e2e image
+        run: |
           function check_if_image_exists() {
             curl -fsSlL -H 'Authorization: bearer ${{ github.token }}' "https://${DOCKER_REGISTRY}/v2/${DOCKER_REPO}/tokenbridge-e2e-$1/manifests/$2" > /dev/null
           }
@@ -150,14 +159,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: |
+      - name: Evaluate e2e docker images tags
+        run: |
           git submodule status > submodule.status
-          echo "::set-env name=E2E_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'Dockerfile.e2e', 'commons', 'oracle-e2e', 'monitor-e2e') }}"
-          echo "::set-env name=ORACLE_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'oracle') }}"
-          echo "::set-env name=MONITOR_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'monitor') }}"
-          echo "::set-env name=UI_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'ui') }}"
-          echo "::set-env name=ALM_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'alm') }}"
-      - if: ${{ matrix.use-cache }} 
+          echo "E2E_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'Dockerfile.e2e', 'commons', 'oracle-e2e', 'monitor-e2e') }}" >> $GITHUB_ENV
+          echo "ORACLE_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'oracle') }}" >> $GITHUB_ENV
+          echo "MONITOR_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'monitor') }}" >> $GITHUB_ENV
+          echo "UI_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'ui') }}" >> $GITHUB_ENV
+          echo "ALM_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'alm') }}" >> $GITHUB_ENV
+      - if: ${{ matrix.use-cache }}
         uses: actions/cache@v2
         id: cache-repo
         with:
@@ -165,8 +175,10 @@ jobs:
             **/node_modules
             contracts/build
           key: ${{ needs.initialize.outputs.cache_key }}
-      - run: docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} -p ${{ github.token }}
-      - run: ${{ !matrix.use-cache || steps.cache-repo.outputs.cache-hit }} && yarn run ${{ matrix.task }}
+      - name: Login to docker registry
+        run: docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} -p ${{ github.token }}
+      - name: yarn run ${{ matrix.task }}
+        run: ${{ !matrix.use-cache || steps.cache-repo.outputs.cache-hit }} && yarn run ${{ matrix.task }}
   deployment:
     runs-on: ubuntu-latest
     needs:
@@ -179,8 +191,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: echo "::set-env name=MOLECULE_RUNNER_TAG::${{ hashFiles('./deployment-e2e/Dockerfile') }}"
-      - run: docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} -p ${{ github.token }}
+      - name: Evaluate e2e molecule runner tag
+        run: echo "MOLECULE_RUNNER_TAG=${{ hashFiles('./deployment-e2e/Dockerfile') }}" >> $GITHUB_ENV
+      - name: Login to docker registry
+        run: docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} -p ${{ github.token }}
       - run: deployment-e2e/molecule.sh ${{ matrix.task }}
   ultimate:
     runs-on: ubuntu-latest
@@ -205,14 +219,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: |
+      - name: Evaluate e2e docker images tags
+        run: |
           git submodule status > submodule.status
-          echo "::set-env name=E2E_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'Dockerfile.e2e', 'commons', 'oracle-e2e', 'monitor-e2e') }}"
-          echo "::set-env name=ORACLE_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'oracle') }}"
-          echo "::set-env name=MONITOR_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'monitor') }}"
-          echo "::set-env name=UI_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'ui') }}"
-          echo "::set-env name=ALM_TAG::${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'alm') }}"
-          echo "::set-env name=MOLECULE_RUNNER_TAG::${{ hashFiles('./deployment-e2e/Dockerfile') }}"
+          echo "E2E_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'Dockerfile.e2e', 'commons', 'oracle-e2e', 'monitor-e2e') }}" >> $GITHUB_ENV
+          echo "ORACLE_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'oracle') }}" >> $GITHUB_ENV
+          echo "MONITOR_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'monitor') }}" >> $GITHUB_ENV
+          echo "UI_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'ui') }}" >> $GITHUB_ENV
+          echo "ALM_TAG=${{ hashFiles('yarn.lock', 'package.json', 'submodule.status', 'commons', 'alm') }}" >> $GITHUB_ENV
+          echo "MOLECULE_RUNNER_TAG=${{ hashFiles('./deployment-e2e/Dockerfile') }}" >> $GITHUB_ENV
       - uses: actions/cache@v2
         id: cache-repo
         with:
@@ -220,12 +235,19 @@ jobs:
             **/node_modules
             contracts/build
           key: ${{ needs.initialize.outputs.cache_key }}
-      - run: docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} -p ${{ github.token }}
-      - run: ${{ steps.cache-repo.outputs.cache-hit }} && e2e-commons/up.sh deploy blocks
-      - run: docker-compose -f ./e2e-commons/docker-compose.yml pull oracle
-      - run: deployment-e2e/molecule.sh ultimate-${{ matrix.task }}
-      - run: sudo chown -R $USER:docker /var/run/docker.sock
-      - if: ${{ matrix.ui-e2e-grep }}
+      - name: Login to docker registry
+        run: docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} -p ${{ github.token }}
+      - name: Deploy contracts
+        run: ${{ steps.cache-repo.outputs.cache-hit }} && e2e-commons/up.sh deploy blocks
+      - name: Pull e2e oracle image
+        run: docker-compose -f ./e2e-commons/docker-compose.yml pull oracle
+      - name: Deploy oracle and ui
+        run: deployment-e2e/molecule.sh ultimate-${{ matrix.task }}
+      - name: Reset docker socket permissions
+        run: sudo chown -R $USER:docker /var/run/docker.sock
+      - name: Run ui e2e tests
+        if: ${{ matrix.ui-e2e-grep }}
         run: cd ui-e2e && xvfb-run yarn mocha -g "${{ matrix.ui-e2e-grep }}" -b ./test.js
-      - if: ${{ !matrix.ui-e2e-grep }}
+      - name: Run oracle e2e tests
+        if: ${{ !matrix.ui-e2e-grep }}
         run: docker-compose -f ./e2e-commons/docker-compose.yml run e2e yarn workspace oracle-e2e run ${{ matrix.task }}


### PR DESCRIPTION
This PR resolves the following GitHub Actions deprecation warnings. 
<img width="806" alt="Screenshot 2020-10-26 at 11 29 34" src="https://user-images.githubusercontent.com/29590423/97149982-87682680-177e-11eb-9e89-5c7e360a1942.png">

Changes are made as it is suggested in the GitHub documentation https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
