### PR TITLE
Handle JSONRPC error codes in web3 providers

### DIFF
--- a/oracle/src/services/HttpListProvider.js
+++ b/oracle/src/services/HttpListProvider.js
@@ -1,6 +1,9 @@
 const fetch = require('node-fetch')
 const promiseRetry = require('promise-retry')
 
+// From EIP-1474 and Infura documentation
+const JSONRPC_ERROR_CODES = [-32603, -32002, -32005]
+
 const defaultOptions = {
   requestTimeout: 0,
   retry: {
@@ -61,6 +64,12 @@ function send(url, payload, options) {
       }
     })
     .then(response => response.json())
+    .then(response => {
+      if (response.error && JSONRPC_ERROR_CODES.includes(response.error.code)) {
+        throw new Error(response.error.message)
+      }
+      return response
+    })
 }
 
 async function trySend(payload, urls, initialIndex, options) {

--- a/oracle/src/services/RedundantHttpListProvider.js
+++ b/oracle/src/services/RedundantHttpListProvider.js
@@ -13,7 +13,6 @@ function RedundantHttpListProvider(urls, options = {}) {
 
   this.urls = urls
   this.options = { ...defaultOptions, ...options }
-  this.currentIndex = 0
 }
 
 RedundantHttpListProvider.prototype.send = async function send(payload, callback) {


### PR DESCRIPTION
The Infura provider reports error codes as an response for a JSON RPC request. E.g.

```
< HTTP/1.1 200 OK
< Date: Wed, 11 Nov 2020 09:48:24 GMT
< Content-Type: application/json
< Content-Length: 88
< Connection: keep-alive
< Vary: Origin
< 
* Connection #0 to host mainnet.infura.io left intact
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"request failed or timed out"}}
```

This PR is to let the oracles to to rely on the returned error code to switch to a fallback RPC URL.