### PR TITLE
ui: update web3 to 1.2.2 to fix getChainId #124

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -23,8 +23,8 @@
     "react-scripts": "3.0.1",
     "react-transition-group": "^2.2.1",
     "sweetalert": "^2.1.0",
-    "web3": "1.0.0-beta.30",
-    "web3-utils": "1.0.0-beta.30"
+    "web3": "^1.2.2",
+    "web3-utils": "^1.2.2"
   },
   "scripts": {
     "lint": "eslint . --ignore-path ../.eslintignore",


### PR DESCRIPTION
fixes: https://github.com/poanetwork/tokenbridge/issues/124 , `web3.eth.getChainId()` is new since web3 1.2.2