### PR TITLE
Add setLogger method to RedundantHttpListProvider

### DIFF
--- a/oracle/src/services/RedundantHttpListProvider.js
+++ b/oracle/src/services/RedundantHttpListProvider.js
@@ -15,6 +15,10 @@ function RedundantHttpListProvider(urls, options = {}) {
   this.options = { ...defaultOptions, ...options }
 }
 
+RedundantHttpListProvider.prototype.setLogger = function(logger) {
+  this.logger = logger.child({ module: `RedundantHttpListProvider:${this.options.name}` })
+}
+
 RedundantHttpListProvider.prototype.send = async function send(payload, callback) {
   try {
     const result = await promiseRetry(retry => {


### PR DESCRIPTION
During testing it was found that `setLogger` method was missed in `RedundantHttpListProvider.js` when the corresponding changes [were introduced](https://github.com/poanetwork/tokenbridge/commit/04f66b243c9652eb4e1314bbc7a394d64120baa3#diff-9e1f8b75f4738d940e381358d5c1caf555ebfebe5542085ba327a3acc077bcdaR30) as part of #500.