### PR TITLE
Fix resend of stuck pending transactions

### DIFF
--- a/oracle/src/sender.js
+++ b/oracle/src/sender.js
@@ -174,16 +174,17 @@ async function main({ msg, ackMsg, nackMsg, channel, scheduleForRetry, scheduleT
           e.message
         )
 
-        if (isResend) {
-          // if transaction resend has failed, schedule it to resend once again
+        const message = e.message.toLowerCase()
+        if (isResend || message.includes('transaction with the same hash was already imported')) {
           resendJobs.push(job)
-        } else if (!e.message.toLowerCase().includes('transaction with the same hash was already imported')) {
+        } else {
           // if initial transaction sending has failed not due to the same hash error
           // send it to the failed tx queue
+          // this will result in the sooner resend attempt than if using resendJobs
           failedTx.push(job)
         }
 
-        if (e.message.toLowerCase().includes('insufficient funds')) {
+        if (message.includes('insufficient funds')) {
           insufficientFunds = true
           const currentBalance = await web3Instance.eth.getBalance(ORACLE_VALIDATOR_ADDRESS)
           minimumBalance = gasLimit.multipliedBy(gasPrice)

--- a/oracle/src/sender.js
+++ b/oracle/src/sender.js
@@ -173,12 +173,14 @@ async function main({ msg, ackMsg, nackMsg, channel, scheduleForRetry, scheduleT
           `Tx Failed for event Tx ${job.transactionReference}.`,
           e.message
         )
-        if (!e.message.toLowerCase().includes('transaction with the same hash was already imported')) {
-          if (isResend) {
-            resendJobs.push(job)
-          } else {
-            failedTx.push(job)
-          }
+
+        if (isResend) {
+          // if transaction resend has failed, schedule it to resend once again
+          resendJobs.push(job)
+        } else if (!e.message.toLowerCase().includes('transaction with the same hash was already imported')) {
+          // if initial transaction sending has failed not due to the same hash error
+          // send it to the failed tx queue
+          failedTx.push(job)
         }
 
         if (e.message.toLowerCase().includes('insufficient funds')) {


### PR DESCRIPTION
This PR is to address behavior when due to congestion in the chain, the privileged oracles' transactions with 0 gasprice could getting stuck. Later, when the oracle is trying to resend them it will get error message that the transaction with the same hash is already in the txpool, and it will not be added back to the resend queue for further check if it was eventually mined. 
As the result another transaction of the same oracle with the same nonce will re-write the original transaction and the bridge message will not be transferred at all.