### PR TITLE
Fix monitor metrics

### DIFF
--- a/monitor/alerts.js
+++ b/monitor/alerts.js
@@ -58,8 +58,6 @@ async function main(eventsInfo) {
       mostRecentTxHash: xAffirmationsMostRecentTxHash,
       transactions: xAffirmationsTxs
     },
-    homeBlockNumber,
-    foreignBlockNumber,
     lastChecked: Math.floor(Date.now() / 1000)
   }
 }

--- a/monitor/alerts.js
+++ b/monitor/alerts.js
@@ -1,18 +1,19 @@
 require('dotenv').config()
 const logger = require('./logger')('alerts')
-const eventsInfo = require('./utils/events')
 const { processedMsgNotDelivered, eventWithoutReference } = require('./utils/message')
 const { BRIDGE_MODES } = require('../commons')
-const { web3Home, web3Foreign, getHomeBlockNumber, getForeignBlockNumber } = require('./utils/web3')
+const { web3Home, web3Foreign } = require('./utils/web3')
 
-async function main() {
+async function main(eventsInfo) {
   const {
+    homeBlockNumber,
+    foreignBlockNumber,
     homeToForeignRequests,
     homeToForeignConfirmations,
     foreignToHomeConfirmations,
     foreignToHomeRequests,
     bridgeMode
-  } = await eventsInfo()
+  } = eventsInfo
 
   let xSignatures
   let xAffirmations
@@ -24,8 +25,6 @@ async function main() {
     xAffirmations = foreignToHomeConfirmations.filter(eventWithoutReference(foreignToHomeRequests))
   }
   logger.debug('building misbehavior blocks')
-  const homeBlockNumber = await getHomeBlockNumber()
-  const foreignBlockNumber = await getForeignBlockNumber()
 
   const baseRange = [false, false, false, false, false]
   const xSignaturesMisbehavior = buildRangesObject(
@@ -59,6 +58,8 @@ async function main() {
       mostRecentTxHash: xAffirmationsMostRecentTxHash,
       transactions: xAffirmationsTxs
     },
+    homeBlockNumber,
+    foreignBlockNumber,
     lastChecked: Math.floor(Date.now() / 1000)
   }
 }

--- a/monitor/checkWorker2.js
+++ b/monitor/checkWorker2.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 const logger = require('./logger')('checkWorker2')
 const eventsStats = require('./eventsStats')
+const getEventsInfo = require('./utils/events')
 const alerts = require('./alerts')
 const { writeFile, createDir } = require('./utils/file')
 const { saveCache } = require('./utils/web3Cache')
@@ -10,8 +11,10 @@ const { MONITOR_BRIDGE_NAME } = process.env
 async function checkWorker2() {
   try {
     createDir(`/responses/${MONITOR_BRIDGE_NAME}`)
+    logger.debug('calling getEventsInfo()')
+    const eventsInfo = await getEventsInfo()
     logger.debug('calling eventsStats()')
-    const evStats = await eventsStats()
+    const evStats = await eventsStats(eventsInfo)
     if (!evStats) throw new Error('evStats is empty: ' + JSON.stringify(evStats))
     evStats.ok =
       (evStats.onlyInHomeDeposits || evStats.home.deliveredMsgNotProcessedInForeign).length === 0 &&
@@ -22,7 +25,7 @@ async function checkWorker2() {
     writeFile(`/responses/${MONITOR_BRIDGE_NAME}/eventsStats.json`, evStats)
 
     logger.debug('calling alerts()')
-    const _alerts = await alerts()
+    const _alerts = await alerts(eventsInfo)
     if (!_alerts) throw new Error('alerts is empty: ' + JSON.stringify(_alerts))
     _alerts.ok = !_alerts.executeAffirmations.mostRecentTxHash && !_alerts.executeSignatures.mostRecentTxHash
     _alerts.health = true

--- a/monitor/eventsStats.js
+++ b/monitor/eventsStats.js
@@ -1,5 +1,4 @@
 require('dotenv').config()
-const eventsInfo = require('./utils/events')
 const {
   processedMsgNotDelivered,
   deliveredMsgNotProcessed,
@@ -15,14 +14,14 @@ const {
   MONITOR_HOME_TO_FOREIGN_CHECK_SENDER
 } = process.env
 
-async function main() {
+async function main(eventsInfo) {
   const {
     homeToForeignRequests,
     homeToForeignConfirmations,
     foreignToHomeConfirmations,
     foreignToHomeRequests,
     bridgeMode
-  } = await eventsInfo()
+  } = eventsInfo
 
   if (bridgeMode === BRIDGE_MODES.ARBITRARY_MESSAGE) {
     return {

--- a/monitor/index.js
+++ b/monitor/index.js
@@ -2,7 +2,6 @@ require('dotenv').config()
 const express = require('express')
 const cors = require('cors')
 const { readFile } = require('./utils/file')
-const { getPrometheusMetrics } = require('./prometheusMetrics')
 
 const app = express()
 const bridgeRouter = express.Router({ mergeParams: true })
@@ -25,7 +24,8 @@ bridgeRouter.get('/:file(validators|eventsStats|alerts|mediators|stuckTransfers|
 
 bridgeRouter.get('/metrics', (req, res, next) => {
   try {
-    const metrics = getPrometheusMetrics(req.params.bridgeName)
+    const { bridgeName } = req.params
+    const metrics = readFile(`./responses/${bridgeName}/metrics.txt`, false)
     res.type('text').send(metrics)
   } catch (e) {
     next(e)

--- a/monitor/metricsWorker.js
+++ b/monitor/metricsWorker.js
@@ -5,11 +5,11 @@ const getPrometheusMetrics = require('./prometheusMetrics')
 
 const { MONITOR_BRIDGE_NAME } = process.env
 
-function metricsWorker() {
+async function metricsWorker() {
   try {
     createDir(`/responses/${MONITOR_BRIDGE_NAME}`)
     logger.debug('calling getPrometheusMetrics()')
-    const metrics = getPrometheusMetrics(MONITOR_BRIDGE_NAME)
+    const metrics = await getPrometheusMetrics(MONITOR_BRIDGE_NAME)
     if (!metrics) throw new Error('metrics is empty: ' + JSON.stringify(metrics))
     writeFile(`/responses/${MONITOR_BRIDGE_NAME}/metrics.txt`, metrics, { stringify: false })
     logger.debug('Done')
@@ -17,5 +17,4 @@ function metricsWorker() {
     logger.error(e)
   }
 }
-
 metricsWorker()

--- a/monitor/metricsWorker.js
+++ b/monitor/metricsWorker.js
@@ -1,0 +1,21 @@
+require('dotenv').config()
+const logger = require('./logger')('metricsWorker')
+const { writeFile, createDir } = require('./utils/file')
+const getPrometheusMetrics = require('./prometheusMetrics')
+
+const { MONITOR_BRIDGE_NAME } = process.env
+
+function metricsWorker() {
+  try {
+    createDir(`/responses/${MONITOR_BRIDGE_NAME}`)
+    logger.debug('calling getPrometheusMetrics()')
+    const metrics = getPrometheusMetrics(MONITOR_BRIDGE_NAME)
+    if (!metrics) throw new Error('metrics is empty: ' + JSON.stringify(metrics))
+    writeFile(`/responses/${MONITOR_BRIDGE_NAME}/metrics.txt`, metrics, { stringify: false })
+    logger.debug('Done')
+  } catch (e) {
+    logger.error(e)
+  }
+}
+
+metricsWorker()

--- a/monitor/package.json
+++ b/monitor/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "check-all": "timeout -s 9 5m node checkWorker.js && timeout -s 9 5m node checkWorker2.js && timeout -s 9 5m node checkWorker3.js",
+    "check-all": "timeout -s 9 5m node checkWorker.js && timeout -s 9 5m node checkWorker2.js && timeout -s 9 5m node checkWorker3.js && timeout -s 9 10s node metricsWorker.js",
     "start": "node index.js",
     "check-and-start": "yarn check-all && yarn start",
     "lint": "eslint . --ignore-path ../.eslintignore",

--- a/monitor/prometheusMetrics.js
+++ b/monitor/prometheusMetrics.js
@@ -2,12 +2,7 @@ require('dotenv').config()
 const logger = require('./logger')('getBalances')
 const { readFile } = require('./utils/file')
 
-const {
-  MONITOR_HOME_TO_FOREIGN_ALLOWANCE_LIST,
-  MONITOR_HOME_TO_FOREIGN_BLOCK_LIST,
-  MONITOR_HOME_VALIDATORS_BALANCE_ENABLE,
-  MONITOR_FOREIGN_VALIDATORS_BALANCE_ENABLE
-} = process.env
+const { MONITOR_HOME_VALIDATORS_BALANCE_ENABLE, MONITOR_FOREIGN_VALIDATORS_BALANCE_ENABLE } = process.env
 
 function BridgeConf(type, validatorsBalanceEnable, alertTargetFunc, failureDirection) {
   this.type = type
@@ -25,6 +20,8 @@ function hasError(obj) {
   return 'error' in obj
 }
 
+// Try to collect all metrics from JSON responses and then
+// discard all unsuccessfully retrieved ones
 function getPrometheusMetrics(bridgeName) {
   const responsePath = jsonName => `./responses/${bridgeName}/${jsonName}.json`
 
@@ -34,22 +31,37 @@ function getPrometheusMetrics(bridgeName) {
   const balancesFile = readFile(responsePath('getBalances'))
 
   if (!hasError(balancesFile)) {
-    const { home: homeBalances, foreign: foreignBalances, ...commonBalances } = balancesFile
-    metrics.balances_home_value = homeBalances.totalSupply
-    metrics.balances_home_txs_deposit = homeBalances.deposits
-    metrics.balances_home_txs_withdrawal = homeBalances.withdrawals
+    const { home, foreign, ...commonBalances } = balancesFile
 
-    metrics.balances_foreign_value = foreignBalances.erc20Balance
-    metrics.balances_foreign_txs_deposit = foreignBalances.deposits
-    metrics.balances_foreign_txs_withdrawal = foreignBalances.withdrawals
+    const balanceMetrics = {
+      // ERC_TO_ERC or ERC_TO_NATIVE mode
+      balances_home_value: home.totalSupply,
+      balances_home_txs_deposit: home.deposits,
+      balances_home_txs_withdrawal: home.withdrawals,
+      balances_foreign_value: foreign.erc20Balance,
+      balances_foreign_txs_deposit: foreign.deposits,
+      balances_foreign_txs_withdrawal: foreign.withdrawals,
 
-    metrics.balances_diff_value = commonBalances.balanceDiff
-    metrics.balances_diff_deposit = commonBalances.depositsDiff
-    metrics.balances_diff_withdrawal = commonBalances.withdrawalDiff
-    if (MONITOR_HOME_TO_FOREIGN_ALLOWANCE_LIST || MONITOR_HOME_TO_FOREIGN_BLOCK_LIST) {
-      metrics.balances_unclaimed_txs = commonBalances.unclaimedDiff
-      metrics.balances_unclaimed_value = commonBalances.unclaimedBalance
+      // Not ARBITRARY_MESSAGE mode
+      balances_diff_value: commonBalances.balanceDiff,
+      balances_diff_deposit: commonBalances.depositsDiff,
+      balances_diff_withdrawal: commonBalances.withdrawalDiff,
+
+      // MONITOR_HOME_TO_FOREIGN_ALLOWANCE_LIST or MONITOR_HOME_TO_FOREIGN_BLOCK_LIST is set
+      balances_unclaimed_txs: commonBalances.unclaimedDiff,
+      balances_unclaimed_value: commonBalances.unclaimedBalance,
+
+      // ARBITRARY_MESSAGE mode
+      txs_home_out: home.toForeign,
+      txs_home_in: home.fromForeign,
+      txs_foreign_out: foreign.toHome,
+      txs_foreign_in: foreign.fromHome,
+      txs_diff_home_out_oracles: commonBalances.fromHomeToForeignDiff,
+      txs_diff_home_out_users: commonBalances.fromHomeToForeignPBUDiff,
+      txs_diff_foreign_out: commonBalances.fromForeignToHomeDiff
     }
+
+    Object.assign(metrics, balanceMetrics)
   }
 
   // Validator metrics

--- a/monitor/utils/events.js
+++ b/monitor/utils/events.js
@@ -242,7 +242,7 @@ async function main(mode) {
 
   if (MONITOR_CACHE_EVENTS === 'true') {
     logger.debug('saving obtained events into cache file')
-    writeFile(cacheFilePath, result, false)
+    writeFile(cacheFilePath, result, { useCwd: false })
   }
   return result
 }

--- a/monitor/utils/events.js
+++ b/monitor/utils/events.js
@@ -236,6 +236,8 @@ async function main(mode) {
     foreignToHomeRequests,
     isExternalErc20,
     bridgeMode,
+    homeBlockNumber,
+    foreignBlockNumber,
     homeDelayedBlockNumber,
     foreignDelayedBlockNumber
   }

--- a/monitor/utils/file.js
+++ b/monitor/utils/file.js
@@ -1,9 +1,10 @@
 const fs = require('fs')
 const path = require('path')
 
-function readFile(filePath) {
+function readFile(filePath, parseJson = true) {
   try {
     const content = fs.readFileSync(filePath)
+    if (!parseJson) return content
     const json = JSON.parse(content)
     const timeDiff = Math.floor(Date.now() / 1000) - json.lastChecked
     return Object.assign({}, json, { timeDiff })
@@ -15,9 +16,15 @@ function readFile(filePath) {
   }
 }
 
-function writeFile(filePath, object, useCwd = true) {
+function writeFile(filePath, object, paramOptions = {}) {
+  const defaultOptions = {
+    useCwd: true,
+    stringify: true
+  }
+  const { useCwd, stringify } = Object.assign({}, defaultOptions, paramOptions)
+
   const fullPath = useCwd ? path.join(process.cwd(), filePath) : filePath
-  fs.writeFileSync(fullPath, JSON.stringify(object, null, 4))
+  fs.writeFileSync(fullPath, stringify ? JSON.stringify(object, null, 4) : object)
 }
 
 function createDir(dirPath) {

--- a/monitor/utils/file.js
+++ b/monitor/utils/file.js
@@ -9,7 +9,7 @@ function readFile(filePath, parseJson = true) {
     const timeDiff = Math.floor(Date.now() / 1000) - json.lastChecked
     return Object.assign({}, json, { timeDiff })
   } catch (e) {
-    console.error(e)
+    console.error('readFlle', e)
     return {
       error: 'the bridge statistics are not available'
     }


### PR DESCRIPTION
Closes #517
Closes #518
Closes #519
Closes #520

Now metrics are collected via the `metricsWorker` in the background (previously they were assembled on the fly). Added handling of AMB metrics. Also, I decided to include information about the last home/foreign block in the `alerts.json` file (`metricsWorker` retrieves this info later). I think this way information about misbehaviour ranges will be more clear.