### PR TITLE
Fix remote shutdown sender behaviour

### DIFF
--- a/oracle/src/shutdownManager.js
+++ b/oracle/src/shutdownManager.js
@@ -43,7 +43,7 @@ async function fetchShutdownFlag() {
   }
 
   if (config.shutdownContractAddress) {
-    const shutdownSelector = web3Side.eth.abi.encodeEventSignature(config.shutdownMethod)
+    const shutdownSelector = web3Side.eth.abi.encodeFunctionSignature(config.shutdownMethod)
     logger.debug(
       { contract: config.shutdownContractAddress, method: config.shutdownMethod, data: shutdownSelector },
       'Fetching shutdown status from contract'

--- a/oracle/src/watcher.js
+++ b/oracle/src/watcher.js
@@ -164,6 +164,8 @@ async function main({ sendToQueue, sendToWorker }) {
         logger.info('Oracle watcher was suspended via the remote shutdown process')
       }
       return
+    } else if (wasShutdown) {
+      logger.info(`Oracle watcher was unsuspended.`)
     }
 
     await checkConditions()


### PR DESCRIPTION
Combination of fixes for found issues:
* Rewrite suspend/unsuspend workflow for sender with rabbitmq channel closing
* Add unsuspend logging
* Replace `encodeEventSignature` with `encodeFunctionSignature`