### PR TITLE
Save and upload services logs in CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,12 @@ jobs:
         run: docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} -p ${{ github.token }}
       - name: yarn run ${{ matrix.task }}
         run: ${{ !matrix.use-cache || steps.cache-repo.outputs.cache-hit }} && yarn run ${{ matrix.task }}
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-${{ matrix.task }}
+          path: e2e-commons/logs
   deployment:
     runs-on: ubuntu-latest
     needs:
@@ -210,3 +216,12 @@ jobs:
         run: sudo chown -R $USER:docker /var/run/docker.sock
       - name: Run oracle e2e tests
         run: docker-compose -f ./e2e-commons/docker-compose.yml run -e ULTIMATE=true e2e yarn workspace oracle-e2e run ${{ matrix.task }}
+      - name: Save logs
+        if: always()
+        run: e2e-commons/down.sh
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-ultimate-${{ matrix.task }}
+          path: e2e-commons/logs

--- a/e2e-commons/down.sh
+++ b/e2e-commons/down.sh
@@ -1,7 +1,33 @@
 #!/usr/bin/env bash
 cd $(dirname $0)
 
-if [ $CI ]; then exit $rc; fi
+if [ $CI ]; then
+  rm -rf logs || true
+
+  mkdir ./logs
+
+  for project in "" validator{1,2,3}; do
+    for container in $(docker-compose -p "$project" ps | tail -n +3 | awk '{print $1}') ; do
+      if [[ -z "$project" ]]; then
+        path="./logs/$container.log"
+      else
+        mkdir -p "./logs/$project"
+        path="./logs/$project/$container.log"
+      fi
+      docker logs "$container" > "$path" 2>&1
+    done
+  done
+
+  touch ../oracle/.env
+  for file in ../oracle/docker-compose-{amb,transfer}.yml; do
+    for container in $(docker-compose -f "$file" ps | tail -n +3 | awk '{print $1}') ; do
+      mkdir -p "./logs/oracle"
+      docker logs "$container" > "./logs/oracle/$container.log" 2>&1
+    done
+  done
+
+  exit $rc;
+fi
 
 ps | grep node | grep -v grep | grep -v yarn | awk '{print "kill " $1}' | /bin/bash
 docker-compose down

--- a/monitor-e2e/package.json
+++ b/monitor-e2e/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "mocha --timeout 120000",
+    "start": "mocha --timeout 120000 --exit",
     "lint": "eslint . --ignore-path ../.eslintignore"
   },
   "author": "",

--- a/oracle-e2e/package.json
+++ b/oracle-e2e/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "mocha --exit",
+    "start": "mocha",
     "lint": "eslint . --ignore-path ../.eslintignore",
     "amb": "mocha test/amb.js",
     "erc-to-native": "mocha test/ercToNative.js",

--- a/oracle-e2e/test/mocha.opts
+++ b/oracle-e2e/test/mocha.opts
@@ -1,1 +1,1 @@
---timeout 120000
+--timeout 120000 --exit


### PR DESCRIPTION
Add CI step for collecting and uploading oracle/monitor service logs. This step could be helpful for debugging purposes.