### PR TITLE
Improvements for the local logs configuration

### DIFF
--- a/deployment/roles/common/templates/docker-logs.j2
+++ b/deployment/roles/common/templates/docker-logs.j2
@@ -1,6 +1,6 @@
 /var/log/docker/*/docker.log {
   rotate 5
-  size 1G
+  size 100M
   compress
   missingok
   delaycompress
@@ -8,7 +8,7 @@
 }
 /var/log/docker/*.log {
   rotate 5
-  size 1G
+  size 100M
   compress
   missingok
   delaycompress

--- a/deployment/roles/oracle/tasks/logging.yml
+++ b/deployment/roles/oracle/tasks/logging.yml
@@ -7,10 +7,26 @@
   loop_control:
     loop_var: file
 
-- name: Set the local container logs configuration file
+- name: Set the oracle's containers local logs configuration file
   template:
     src: 31-oracle-docker.conf.j2
     dest: /etc/rsyslog.d/31-oracle-docker.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Set the redis container local logs configuration file
+  template:
+    src: 32-redis-docker.conf.j2
+    dest: /etc/rsyslog.d/32-redis-docker.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Set the rabbit MQ container local logs configuration file
+  template:
+    src: 33-rabbit-docker.conf.j2
+    dest: /etc/rsyslog.d/33-rabbit-docker.conf
     owner: root
     group: root
     mode: 0644

--- a/deployment/roles/oracle/templates/32-redis-docker.conf.j2
+++ b/deployment/roles/oracle/templates/32-redis-docker.conf.j2
@@ -1,0 +1,11 @@
+$FileCreateMode 0644
+template(name="DockerLogFileName_Redis" type="list") {
+   constant(value="/var/log/docker/")
+   property(name="syslogtag" securepath="replace" regex.type="ERE" regex.submatch="1" regex.expression="oracle_(.*redis.*)\\/[a-zA-Z0-9]+\\[")
+   constant(value="/docker.log")
+}
+
+if $programname contains 'oracle' and $programname contains 'redis' then \
+  ?DockerLogFileName_Redis
+
+$FileCreateMode 0600

--- a/deployment/roles/oracle/templates/33-rabbit-docker.conf.j2
+++ b/deployment/roles/oracle/templates/33-rabbit-docker.conf.j2
@@ -1,0 +1,11 @@
+$FileCreateMode 0644
+template(name="DockerLogFileName_Rabbit" type="list") {
+   constant(value="/var/log/docker/")
+   property(name="syslogtag" securepath="replace" regex.type="ERE" regex.submatch="1" regex.expression="oracle_(.*rabbit.*)\\/[a-zA-Z0-9]+\\[")
+   constant(value="/docker.log")
+}
+
+if $programname contains 'oracle' and $programname contains 'rabbit' then \
+  ?DockerLogFileName_Rabbit
+
+$FileCreateMode 0600


### PR DESCRIPTION
The following changes are suggested to improve the local logging configuration by deployment scripts:
  - Local logs will be rotated when 100M threshold exceeds. It must reduce requirements to the disk usage.
  - RedisDB and RabbitMQ logs are forwarded to dedicated files (wildcards must work for different container namings like `oracle_redis_1`, `oracle_redis-alpha_1`, `oracle_nuff-redis_1`)