### PR TITLE
Missing case when check nonce error

### DIFF
--- a/oracle/src/utils/utils.js
+++ b/oracle/src/utils/utils.js
@@ -169,7 +169,8 @@ function isNonceError(e) {
     message.includes('transaction nonce is too low') ||
     message.includes('nonce too low') ||
     message.includes('transaction with same nonce in the queue') ||
-    message.includes('oldnonce')
+    message.includes('oldnonce') ||
+    message.includes(`the tx doesn't have the correct nonce`)
   )
 }
 


### PR DESCRIPTION
I found a missing case when checking the nonce error.

Error: "The tx doesn't have the correct nonce" not contained in isNonceError function so the nonce in Redis does not update so it is a loop error

![ca26335d9543c0983b864d32f47d0026](https://user-images.githubusercontent.com/100658449/162120003-de6b1506-6409-4501-af6c-80a53dfd1ca1.png)

