### PR TITLE
Update test description in `processCollectedSignatures.test.js` with expected exception to be thrown

### DIFF
--- a/oracle/test/processCollectedSignatures.test.js
+++ b/oracle/test/processCollectedSignatures.test.js
@@ -98,7 +98,7 @@ describe('processCollectedSignatures', () => {
       await expect(result).to.be.rejectedWith(errors.IncompatibleContractError)
     })
 
-    it('should throw an IncompatibleContractError if the signature is invalid', async () => {
+    it('should throw an InvalidValidatorError if the signature is invalid', async () => {
       // given
       const estimateGasStub = sinon.stub()
       estimateGasStub.rejects(new Error())


### PR DESCRIPTION
Update misleading description (expected exception) for the test that checks if the `InvalidValidatorError` exception is thrown when the signature is invalid.